### PR TITLE
feat: disable public ip for containers

### DIFF
--- a/terragrunt/aws/software_asset_inventory/api_server.tf
+++ b/terragrunt/aws/software_asset_inventory/api_server.tf
@@ -17,9 +17,8 @@ resource "aws_ecs_service" "dependencytrack_api" {
   }
 
   network_configuration {
-    security_groups  = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
-    subnets          = var.vpc_private_subnet_ids
-    assign_public_ip = true
+    security_groups = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
+    subnets         = var.vpc_private_subnet_ids
   }
 
   tags = {

--- a/terragrunt/aws/software_asset_inventory/frontend.tf
+++ b/terragrunt/aws/software_asset_inventory/frontend.tf
@@ -17,9 +17,8 @@ resource "aws_ecs_service" "dependencytrack_frontend" {
   }
 
   network_configuration {
-    security_groups  = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
-    subnets          = var.vpc_private_subnet_ids
-    assign_public_ip = true
+    security_groups = [aws_security_group.dependencytrack.id, module.dependencytrack_db.proxy_security_group_id]
+    subnets         = var.vpc_private_subnet_ids
   }
 
   tags = {


### PR DESCRIPTION
Since we're no longer using the VPC peering approach it's no longer necessary to have public ips for the ECS tasks.