### PR TITLE
feat: last batch of refactors to bring in-line with old peering setup

### DIFF
--- a/terragrunt/aws/base/inputs.tf
+++ b/terragrunt/aws/base/inputs.tf
@@ -1,0 +1,5 @@
+variable "ssm_prefix" {
+  description = "(Required) Prefix to apply to all key names"
+  type        = string
+  default     = "base"
+}

--- a/terragrunt/aws/base/outputs.tf
+++ b/terragrunt/aws/base/outputs.tf
@@ -1,8 +1,3 @@
-output "cartography_repository_url" {
-  description = "The ECR URL for the cartography repository"
-  value       = aws_ecr_repository.cartography.repository_url
-}
-
 output "security_tools_vpc_id" {
   description = "The VPC ID for the security tools"
   value       = module.vpc.vpc_id

--- a/terragrunt/aws/base/smtp.tf
+++ b/terragrunt/aws/base/smtp.tf
@@ -11,20 +11,31 @@ resource "aws_iam_access_key" "security_tools" {
   user = aws_iam_user.security_tools.name
 }
 
+resource "aws_iam_group_membership" "security_tools_automation" {
+  name = "SecurityToolsNotificationIAMGroupMembership"
+
+  users = [
+    aws_iam_user.security_tools.name,
+  ]
+
+  group = aws_iam_group.security_tools_automation.name
+}
+
+resource "aws_iam_group" "security_tools_automation" {
+  name = "automation-security-tools-notification-group"
+  path = "/automation/securitytools/"
+}
+
+resource "aws_iam_group_policy" "security_tools_automation_policy" {
+  name   = "automation-security-tools-notification-group-policy"
+  group  = aws_iam_group.security_tools_automation.name
+  policy = data.aws_iam_policy_document.security_tools_automation.json
+}
+
 # Attaches a Managed IAM Policy to SES Email Identity resource
-data "aws_iam_policy_document" "policy_document" {
+data "aws_iam_policy_document" "security_tools_automation" {
   statement {
     actions   = ["ses:SendEmail", "ses:SendRawEmail"]
     resources = [aws_ses_email_identity.security_tools.arn]
   }
-}
-
-resource "aws_iam_policy" "policy" {
-  name   = "SecurityToolsNotificationPolicy"
-  policy = data.aws_iam_policy_document.policy_document.json
-}
-
-resource "aws_iam_user_policy_attachment" "user_policy" {
-  user       = aws_iam_user.security_tools.name
-  policy_arn = aws_iam_policy.policy.arn
 }

--- a/terragrunt/aws/base/smtp.tf
+++ b/terragrunt/aws/base/smtp.tf
@@ -1,6 +1,6 @@
 # Provides an SES email identity resource
 resource "aws_ses_email_identity" "security_tools" {
-  email = "info@security.cdssandbox.xyz"
+  email = "no-reply@security.cdssandbox.xyz"
 }
 
 resource "aws_iam_user" "security_tools" {

--- a/terragrunt/aws/base/smtp.tf
+++ b/terragrunt/aws/base/smtp.tf
@@ -1,8 +1,3 @@
-# Provides an SES email identity resource
-resource "aws_ses_email_identity" "security_tools" {
-  email = "no-reply@security.cdssandbox.xyz"
-}
-
 resource "aws_iam_user" "security_tools" {
   name = "SecurityToolsNotificationIAMUser"
 }
@@ -36,6 +31,6 @@ resource "aws_iam_group_policy" "security_tools_automation_policy" {
 data "aws_iam_policy_document" "security_tools_automation" {
   statement {
     actions   = ["ses:SendEmail", "ses:SendRawEmail"]
-    resources = [aws_ses_email_identity.security_tools.arn]
+    resources = ["arn:aws:ses:${var.region}:${var.account_id}:identity/${var.domain_name}"]
   }
 }

--- a/terragrunt/aws/base/smtp.tf
+++ b/terragrunt/aws/base/smtp.tf
@@ -1,0 +1,30 @@
+# Provides an SES email identity resource
+resource "aws_ses_email_identity" "security_tools" {
+  email = "info@security.cdssandbox.xyz"
+}
+
+resource "aws_iam_user" "security_tools" {
+  name = "SecurityToolsNotificationIAMUser"
+}
+
+resource "aws_iam_access_key" "security_tools" {
+  user = aws_iam_user.security_tools.name
+}
+
+# Attaches a Managed IAM Policy to SES Email Identity resource
+data "aws_iam_policy_document" "policy_document" {
+  statement {
+    actions   = ["ses:SendEmail", "ses:SendRawEmail"]
+    resources = [aws_ses_email_identity.security_tools.arn]
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  name   = "SecurityToolsNotificationPolicy"
+  policy = data.aws_iam_policy_document.policy_document.json
+}
+
+resource "aws_iam_user_policy_attachment" "user_policy" {
+  user       = aws_iam_user.security_tools.name
+  policy_arn = aws_iam_policy.policy.arn
+}

--- a/terragrunt/aws/base/ssm.tf
+++ b/terragrunt/aws/base/ssm.tf
@@ -1,0 +1,23 @@
+resource "aws_ssm_parameter" "smtp_username" {
+  name  = "/${var.ssm_prefix}/smtp_username"
+  type  = "SecureString"
+  value = aws_iam_access_key.security_tools.id
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = "${var.product_name}"
+  }
+}
+
+resource "aws_ssm_parameter" "smtp_password" {
+  name  = "/${var.ssm_prefix}/smtp_password"
+  type  = "SecureString"
+  value = aws_iam_access_key.security_tools.ses_smtp_password_v4
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = "${var.product_name}"
+  }
+}

--- a/terragrunt/aws/base/vpc.tf
+++ b/terragrunt/aws/base/vpc.tf
@@ -31,3 +31,16 @@ resource "aws_flow_log" "cloud-based-sensor" {
     Product               = var.product_name
   }
 }
+
+### NACL
+
+resource "aws_network_acl_rule" "smtp_egress" {
+  network_acl_id = module.vpc.main_nacl_id
+  rule_number    = 200
+  egress         = true
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 465
+  to_port        = 465
+}

--- a/terragrunt/aws/base/vpc.tf
+++ b/terragrunt/aws/base/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source = "github.com/cds-snc/terraform-modules?ref=v2.0.5//vpc"
-  name   = var.product_name
+  name   = "${var.product_name}-${var.tool_name}"
 
   high_availability  = true
   enable_flow_log    = false

--- a/terragrunt/aws/cloud_asset_inventory/cartography.tf
+++ b/terragrunt/aws/cloud_asset_inventory/cartography.tf
@@ -9,7 +9,7 @@ data "template_file" "cartography_container_definition" {
     AWS_LOGS_GROUP           = aws_cloudwatch_log_group.cartography.name
     AWS_LOGS_REGION          = var.region
     AWS_LOGS_STREAM_PREFIX   = "${local.cartography_service_name}-task"
-    CARTOGRAPHY_IMAGE        = "${var.cartography_repository_url}:latest"
+    CARTOGRAPHY_IMAGE        = "${aws_ecr_repository.cartography.repository_url}:latest"
     CARTOGRAPHY_SERVICE_NAME = local.cartography_service_name
     NEO4J_SECRETS_PASSWORD   = aws_ssm_parameter.neo4j_password.arn
   }
@@ -31,7 +31,7 @@ resource "aws_ecs_task_definition" "cartography" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -42,6 +42,6 @@ resource "aws_cloudwatch_log_group" "cartography" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/container_execution_role.tf
+++ b/terragrunt/aws/cloud_asset_inventory/container_execution_role.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "cartography_container_execution_role" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -111,6 +111,6 @@ resource "aws_iam_policy" "cartography_policies" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/ecr.tf
+++ b/terragrunt/aws/cloud_asset_inventory/ecr.tf
@@ -1,6 +1,3 @@
-#
-# ECR
-#
 resource "aws_ecr_repository" "cartography" {
   name                 = "${var.product_name}/cloud_asset_inventory/cartography"
   image_tag_mutability = "MUTABLE"
@@ -16,6 +13,6 @@ resource "aws_ecr_repository" "cartography" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/ecs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/ecs.tf
@@ -15,6 +15,6 @@ resource "aws_ecs_cluster" "cloud_asset_discovery" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/efs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/efs.tf
@@ -4,7 +4,7 @@ resource "aws_efs_file_system" "neo4j" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/iam.tf
+++ b/terragrunt/aws/cloud_asset_inventory/iam.tf
@@ -18,7 +18,7 @@ resource "aws_iam_role" "cartography_task_execution_role" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -87,32 +87,32 @@ resource "aws_iam_policy" "cartography_task_execution_policies" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
 ### WAF IAM role
 
 resource "aws_iam_role" "waf_log_role" {
-  name               = "${var.product_name}-logs"
+  name               = "${var.product_name}-${var.tool_name}-logs"
   assume_role_policy = data.aws_iam_policy_document.firehose_assume_role.json
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
 resource "aws_iam_policy" "write_waf_logs" {
-  name        = "${var.product_name}_WriteLogs"
+  name        = "${var.product_name}-${var.tool_name}_WriteLogs"
   description = "Allow writing WAF logs to S3 + CloudWatch"
   policy      = data.aws_iam_policy_document.write_waf_logs.json
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/inputs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/inputs.tf
@@ -35,11 +35,6 @@ variable "ssm_prefix" {
   default     = "cartography"
 }
 
-variable "cartography_repository_url" {
-  description = "(Required) URL to the cartography repository"
-  type        = string
-}
-
 variable "vpc_private_subnet_cidrs" {
   description = "(Required) The private subnet CIDRs for the VPC"
   type        = list(string)

--- a/terragrunt/aws/cloud_asset_inventory/lb.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lb.tf
@@ -20,7 +20,7 @@ resource "aws_lb" "cartography" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -35,7 +35,7 @@ resource "aws_lb_target_group" "neo4j" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -50,7 +50,7 @@ resource "aws_lb_target_group" "bolt" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -69,7 +69,7 @@ resource "aws_lb_listener" "neo4j" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -86,6 +86,6 @@ resource "aws_lb_listener" "bolt" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/neo4j.tf
+++ b/terragrunt/aws/cloud_asset_inventory/neo4j.tf
@@ -35,7 +35,7 @@ resource "aws_ecs_service" "neo4j" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -76,7 +76,7 @@ resource "aws_ecs_task_definition" "neo4j" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -87,6 +87,6 @@ resource "aws_cloudwatch_log_group" "neo4j" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/security_groups.tf
+++ b/terragrunt/aws/cloud_asset_inventory/security_groups.tf
@@ -84,6 +84,6 @@ resource "aws_security_group" "cartography" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/service_discovery.tf
+++ b/terragrunt/aws/cloud_asset_inventory/service_discovery.tf
@@ -6,7 +6,7 @@ resource "aws_service_discovery_private_dns_namespace" "internal" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -31,6 +31,6 @@ resource "aws_service_discovery_service" "neo4j" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/cloud_asset_inventory/ssm.tf
+++ b/terragrunt/aws/cloud_asset_inventory/ssm.tf
@@ -22,7 +22,7 @@ resource "aws_ssm_parameter" "neo4j_password" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -34,7 +34,7 @@ resource "aws_ssm_parameter" "neo4j_auth" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -47,7 +47,7 @@ resource "aws_ssm_parameter" "asset_inventory_account_list" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/state_machine.tf
+++ b/terragrunt/aws/cloud_asset_inventory/state_machine.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_event_rule" "asset_inventory_cartography" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -40,7 +40,7 @@ resource "aws_sfn_state_machine" "asset_inventory_cartography" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -51,7 +51,7 @@ resource "aws_iam_role" "asset_inventory_cartography_state_machine" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -81,13 +81,18 @@ resource "aws_iam_policy" "asset_inventory_cartography_state_machine" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
 resource "aws_iam_role_policy_attachment" "asset_inventory_cartography_state_machine" {
   role       = aws_iam_role.asset_inventory_cartography_state_machine.name
   policy_arn = aws_iam_policy.asset_inventory_cartography_state_machine.arn
+}
+
+resource "aws_iam_role_policy_attachment" "sfn_cloudwatch_full_access" {
+  role       = aws_iam_role.asset_inventory_cartography_state_machine.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchEventsFullAccess"
 }
 
 data "aws_iam_policy_document" "asset_inventory_cartography_state_machine" {

--- a/terragrunt/aws/software_asset_inventory/alb.tf
+++ b/terragrunt/aws/software_asset_inventory/alb.tf
@@ -22,13 +22,13 @@ resource "aws_lb" "dependencytrack" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
 resource "aws_lb_target_group" "dependencytrack_api" {
   name                 = "dependencytrack-api"
-  port                 = 8081
+  port                 = 8080
   protocol             = "HTTP"
   target_type          = "ip"
   deregistration_delay = 30
@@ -48,7 +48,7 @@ resource "aws_lb_target_group" "dependencytrack_api" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -74,7 +74,7 @@ resource "aws_lb_target_group" "dependencytrack_frontend" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -94,7 +94,7 @@ resource "aws_lb_listener" "frontend" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -114,6 +114,6 @@ resource "aws_lb_listener" "api" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/software_asset_inventory/api_server.tf
+++ b/terragrunt/aws/software_asset_inventory/api_server.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_service" "dependencytrack_api" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -73,7 +73,7 @@ resource "aws_ecs_task_definition" "dependencytrack_api" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -84,6 +84,6 @@ resource "aws_cloudwatch_log_group" "dependencytrack_api" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
+++ b/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
@@ -65,7 +65,7 @@
       }
     ],
     "essential" : true,
-    "image" : "${DEPENDENCYTRACK_API_IMAGE}",,
+    "image" : "${DEPENDENCYTRACK_API_IMAGE}",
     "mountPoints" : [
       {
         "sourceVolume" : "${DEPENDENCYTRACK_SERVICE_NAME}",

--- a/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
+++ b/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
@@ -38,10 +38,34 @@
       {
         "name" : "ALPINE_DATABASE_POOL_MAX_LIFETIME",
         "value" : "600000"
+      },
+      {
+        "name" : "ALPINE_CORS_ENABLED",
+        "value" : "true"
+      },
+      {
+        "name" : "ALPINE_CORS_ALLOW_ORIGIN",
+        "value" : "*"
+      },
+      {
+        "name" : "ALPINE_CORS_ALLOW_METHODS",
+        "value" : "GET, POST, PUT, DELETE, OPTIONS"
+      },
+      {
+        "name" : "ALPINE_CORS_ALLOW_HEADERS",
+        "value" : "Origin, Content-Type, Authorization, X-Requested-With, Content-Length, Accept, Origin, X-Api-Key, X-Total-Count, *"
+      },
+      {
+        "name" : "ALPINE_CORS_ALLOW_CREDENTIALS",
+        "value" : "true"
+      },
+      {
+        "name" : "ALPINE_CORS_MAX_AGE",
+        "value" : "3600"
       }
     ],
     "essential" : true,
-    "image" : "dependencytrack/apiserver:latest",
+    "image" : "${DEPENDENCYTRACK_API_IMAGE}",,
     "mountPoints" : [
       {
         "sourceVolume" : "${DEPENDENCYTRACK_SERVICE_NAME}",

--- a/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_frontend.json.tmpl
+++ b/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_frontend.json.tmpl
@@ -5,6 +5,10 @@
       {
         "name" : "API_BASE_URL",
         "value" : "https://api.dependencies.security.cdssandbox.xyz"
+      },
+      {
+        "name" : "API_WITH_CREDENTIALS",
+        "value" : "true"
       }
     ],
     "essential" : true,

--- a/terragrunt/aws/software_asset_inventory/container_execution_role_api.tf
+++ b/terragrunt/aws/software_asset_inventory/container_execution_role_api.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "dependencytrack_api_container_execution_role" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -98,6 +98,6 @@ resource "aws_iam_policy" "dependencytrack_api_policies" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/software_asset_inventory/container_execution_role_frontend.tf
+++ b/terragrunt/aws/software_asset_inventory/container_execution_role_frontend.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "dependencytrack_frontend_container_execution_role" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/software_asset_inventory/ecr.tf
+++ b/terragrunt/aws/software_asset_inventory/ecr.tf
@@ -1,0 +1,18 @@
+resource "aws_ecr_repository" "dependencytrack_frontend" {
+  name                 = "${var.product_name}/software_asset_inventory/dependencytrack_frontend"
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = "${var.product_name}-${var.tool_name}"
+  }
+}

--- a/terragrunt/aws/software_asset_inventory/ecs.tf
+++ b/terragrunt/aws/software_asset_inventory/ecs.tf
@@ -9,6 +9,6 @@ resource "aws_ecs_cluster" "software_asset_tracking" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/software_asset_inventory/efs.tf
+++ b/terragrunt/aws/software_asset_inventory/efs.tf
@@ -4,7 +4,7 @@ resource "aws_efs_file_system" "dependencytrack" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -33,7 +33,7 @@ resource "aws_efs_access_point" "dependencytrack" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/software_asset_inventory/frontend.tf
+++ b/terragrunt/aws/software_asset_inventory/frontend.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_service" "dependencytrack_frontend" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -35,7 +35,7 @@ data "template_file" "dependencytrack_frontend_container_definition" {
     AWS_LOGS_GROUP                        = aws_cloudwatch_log_group.dependencytrack_frontend.name
     AWS_LOGS_REGION                       = var.region
     AWS_LOGS_STREAM_PREFIX                = "${local.dependencytrack_frontend_service_name}-task"
-    DEPENDENCYTRACK_FRONTEND_IMAGE        = "${var.dependencytrack_frontend_image}:${var.dependencytrack_frontend_image_tag}"
+    DEPENDENCYTRACK_FRONTEND_IMAGE        = "794722365809.dkr.ecr.ca-central-1.amazonaws.com/security-tools/software_asset_inventory/dependencytrack_frontend:latest"
     DEPENDENCYTRACK_FRONTEND_SERVICE_NAME = local.dependencytrack_frontend_service_name
   }
 }
@@ -56,7 +56,7 @@ resource "aws_ecs_task_definition" "dependencytrack_frontend" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -67,6 +67,6 @@ resource "aws_cloudwatch_log_group" "dependencytrack_frontend" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/software_asset_inventory/iam.tf
+++ b/terragrunt/aws/software_asset_inventory/iam.tf
@@ -10,7 +10,7 @@ resource "aws_iam_role" "dependencytrack_task_execution_role" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -50,25 +50,25 @@ resource "aws_iam_role_policy_attachment" "ecs_container_registery_policies" {
 ### WAF IAM role
 
 resource "aws_iam_role" "waf_log_role" {
-  name               = "${var.product_name}-logs"
+  name               = "${var.product_name}-${var.tool_name}-logs"
   assume_role_policy = data.aws_iam_policy_document.firehose_assume_role.json
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
 resource "aws_iam_policy" "write_waf_logs" {
-  name        = "${var.product_name}_WriteLogs"
+  name        = "${var.product_name}-${var.tool_name}_WriteLogs"
   description = "Allow writing WAF logs to S3 + CloudWatch"
   policy      = data.aws_iam_policy_document.write_waf_logs.json
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/software_asset_inventory/security_groups.tf
+++ b/terragrunt/aws/software_asset_inventory/security_groups.tf
@@ -79,6 +79,14 @@ resource "aws_security_group" "dependencytrack" {
     self        = true
   }
 
+  egress {
+    description = "Outbound access to SMTP"
+    from_port   = 465
+    to_port     = 465
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true

--- a/terragrunt/aws/software_asset_inventory/security_groups.tf
+++ b/terragrunt/aws/software_asset_inventory/security_groups.tf
@@ -82,6 +82,6 @@ resource "aws_security_group" "dependencytrack" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/software_asset_inventory/ssm.tf
+++ b/terragrunt/aws/software_asset_inventory/ssm.tf
@@ -25,7 +25,7 @@ resource "aws_ssm_parameter" "dependencytrack_db_password" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -37,6 +37,6 @@ resource "aws_ssm_parameter" "dependencytrack_db_user" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/acm.tf
+++ b/terragrunt/aws/sso_proxy/acm.tf
@@ -2,13 +2,14 @@ resource "aws_acm_certificate" "internal_domain" {
   domain_name = var.domain_name
   subject_alternative_names = [
     "*.${var.domain_name}",
+    "*.dependencies.${var.domain_name}",
   ]
   validation_method = "DNS"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 
   lifecycle {
@@ -22,7 +23,7 @@ resource "aws_route53_zone" "internal_domain" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/sso_proxy/acm.tf
+++ b/terragrunt/aws/sso_proxy/acm.tf
@@ -109,3 +109,25 @@ resource "aws_route53_record" "security_tools_route_53_dmarc_txt" {
     "v=DMARC1;p=quarantine;pct=75;rua=mailto:security@cds-snc.ca"
   ]
 }
+
+### SES email from
+resource "aws_ses_domain_mail_from" "security_tools" {
+  domain           = aws_ses_domain_identity.security_tools.domain
+  mail_from_domain = "bounce.${aws_ses_domain_identity.security_tools.domain}"
+}
+
+resource "aws_route53_record" "security_tools_ses_domain_mail_from_mx" {
+  zone_id = aws_route53_zone.internal_domain.id
+  name    = aws_ses_domain_mail_from.security_tools.mail_from_domain
+  type    = "MX"
+  ttl     = "600"
+  records = ["10 feedback-smtp.${var.region}.amazonses.com"]
+}
+
+resource "aws_route53_record" "security_tools_ses_domain_mail_from_txt" {
+  zone_id = aws_route53_zone.internal_domain.id
+  name    = aws_ses_domain_mail_from.security_tools.mail_from_domain
+  type    = "TXT"
+  ttl     = "600"
+  records = ["v=spf1 include:amazonses.com -all"]
+}

--- a/terragrunt/aws/sso_proxy/alb.tf
+++ b/terragrunt/aws/sso_proxy/alb.tf
@@ -21,7 +21,7 @@ resource "aws_lb" "pomerium" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -52,7 +52,7 @@ resource "aws_lb_target_group" "sso_proxy" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -74,7 +74,7 @@ resource "aws_lb_listener" "http" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -94,7 +94,7 @@ resource "aws_lb_listener" "https" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -33,7 +33,7 @@
                 is: cds-snc.ca
 
 - from: https://dependencies.security.cdssandbox.xyz
-  to: https://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8080
+  to: http://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8080
   preserve_host_header: true
   policy:
       - allow:
@@ -41,10 +41,10 @@
             - domain:
                 is: cds-snc.ca
 
-- from: https://sbom.security.cdssandbox.xyz
-  to: https://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8081
+- from: https://sbom.dependencies.security.cdssandbox.xyz
+  to: http://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8081
   preserve_host_header: true
-  allow_public_unauthenticated_access: true
+  cors_allow_preflight: true
   policy:
       - allow:
           or:
@@ -52,8 +52,11 @@
                 is: POST
 
 - from: https://api.dependencies.security.cdssandbox.xyz
-  to: https://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8081
+  to: http://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8081
   preserve_host_header: true
+  cors_allow_preflight: true
+  set_response_headers:
+    Access-Control-Allow-Origin: https://dependencies.security.cdssandbox.xyz
   policy:
       - allow:
           or:

--- a/terragrunt/aws/sso_proxy/container_execution_role.tf
+++ b/terragrunt/aws/sso_proxy/container_execution_role.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "pomerium_container_execution_role" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -84,6 +84,6 @@ resource "aws_iam_policy" "pomerium_policies" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/ecs.tf
+++ b/terragrunt/aws/sso_proxy/ecs.tf
@@ -9,6 +9,6 @@ resource "aws_ecs_cluster" "sso_proxy" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/iam.tf
+++ b/terragrunt/aws/sso_proxy/iam.tf
@@ -10,7 +10,7 @@ resource "aws_iam_role" "pomerium_task_execution_role" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -50,25 +50,25 @@ resource "aws_iam_role_policy_attachment" "ecs_container_registery_policies" {
 ### WAF IAM role
 
 resource "aws_iam_role" "waf_log_role" {
-  name               = "${var.product_name}-logs"
+  name               = "${var.product_name}-${var.tool_name}-logs"
   assume_role_policy = data.aws_iam_policy_document.firehose_assume_role.json
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
 resource "aws_iam_policy" "write_waf_logs" {
-  name        = "${var.product_name}_WriteLogs"
+  name        = "${var.product_name}-${var.tool_name}_WriteLogs"
   description = "Allow writing WAF logs to S3 + CloudWatch"
   policy      = data.aws_iam_policy_document.write_waf_logs.json
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/aws/sso_proxy/pomerium_sso.tf
+++ b/terragrunt/aws/sso_proxy/pomerium_sso.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_service" "pomerium_sso_proxy" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -72,7 +72,7 @@ resource "aws_ecs_task_definition" "pomerium_sso_proxy" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -83,6 +83,6 @@ resource "aws_cloudwatch_log_group" "pomerium_sso_proxy" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/pomerium_sso_auth.tf
+++ b/terragrunt/aws/sso_proxy/pomerium_sso_auth.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_service" "pomerium_sso_proxy_auth" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -56,7 +56,7 @@ resource "aws_ecs_task_definition" "pomerium_sso_proxy_auth" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -67,6 +67,6 @@ resource "aws_cloudwatch_log_group" "pomerium_sso_proxy_auth" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/security_groups.tf
+++ b/terragrunt/aws/sso_proxy/security_groups.tf
@@ -85,9 +85,45 @@ resource "aws_security_group" "pomerium" {
     self        = true
   }
 
+  egress {
+    description = "Outbound access to neo4j http"
+    from_port   = 7474
+    to_port     = 7474
+    protocol    = "tcp"
+    cidr_blocks = var.vpc_private_subnet_cidrs
+    self        = true
+  }
+
+  egress {
+    description = "Outbound access to neo4j bolt"
+    from_port   = 7687
+    to_port     = 7687
+    protocol    = "tcp"
+    cidr_blocks = var.vpc_private_subnet_cidrs
+    self        = true
+  }
+
+  egress {
+    description = "Outbound access to dependency track frontend"
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = var.vpc_private_subnet_cidrs
+    self        = true
+  }
+
+  egress {
+    description = "Outbound access to dependency track api"
+    from_port   = 8081
+    to_port     = 8081
+    protocol    = "tcp"
+    cidr_blocks = var.vpc_private_subnet_cidrs
+    self        = true
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/service_discovery.tf
+++ b/terragrunt/aws/sso_proxy/service_discovery.tf
@@ -6,7 +6,7 @@ resource "aws_service_discovery_private_dns_namespace" "internal" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -31,6 +31,6 @@ resource "aws_service_discovery_service" "auth" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/ssm.tf
+++ b/terragrunt/aws/sso_proxy/ssm.tf
@@ -6,7 +6,7 @@ resource "aws_ssm_parameter" "pomerium_google_client_id" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -18,7 +18,7 @@ resource "aws_ssm_parameter" "pomerium_google_client_secret" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -30,7 +30,7 @@ resource "aws_ssm_parameter" "session_cookie_secret" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -42,7 +42,7 @@ resource "aws_ssm_parameter" "session_key" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -54,7 +54,7 @@ resource "aws_ssm_parameter" "pomerium_client_id" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
@@ -66,6 +66,6 @@ resource "aws_ssm_parameter" "pomerium_client_secret" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }

--- a/terragrunt/aws/sso_proxy/waf.tf
+++ b/terragrunt/aws/sso_proxy/waf.tf
@@ -14,7 +14,7 @@ resource "aws_wafv2_web_acl" "sso_proxy_waf" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 
   default_action {
@@ -169,12 +169,12 @@ resource "aws_cloudwatch_log_group" "sso_proxy_waf" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "sso_proxy_waf" {
-  name        = "aws-waf-logs-${var.product_name}"
+  name        = "aws-waf-logs-${var.product_name}-${var.tool_name}"
   destination = "extended_s3"
 
   server_side_encryption {
@@ -191,7 +191,7 @@ resource "aws_kinesis_firehose_delivery_stream" "sso_proxy_waf" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-    Product               = var.product_name
+    Product               = "${var.product_name}-${var.tool_name}"
   }
 }
 

--- a/terragrunt/env/base/terragrunt.hcl
+++ b/terragrunt/env/base/terragrunt.hcl
@@ -3,6 +3,7 @@ terraform {
 }
 
 inputs = {
+  tool_name = "base"
 }
 
 include {

--- a/terragrunt/env/cloud_asset_inventory/terragrunt.hcl
+++ b/terragrunt/env/cloud_asset_inventory/terragrunt.hcl
@@ -8,17 +8,11 @@ dependencies {
 
 dependency "base" {
   config_path = "../base"
-
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs = {
-    cartography_repository_url = "https://12345678910.dkr.ecr.region.amazonaws.com/foo"
-  }
 }
 
 inputs = {
-  product_name                                    = "security-tools-cloud-asset-inventory"
+  tool_name                                       = "cloud-asset-inventory"
   asset_inventory_managed_accounts                = split("\n", chomp(replace(file("configs/accounts.txt"), "\"", "")))
-  cartography_repository_url                      = dependency.base.outputs.cartography_repository_url
   neo4j_image                                     = "neo4j"
   neo4j_image_tag                                 = "3.5.32@sha256:a5e2dc0ee57c7943342c981b5037c1bf961980f00fe8d6f6304d2b24102d6f5b"
   cloud_asset_inventory_vpc_peering_connection_id = "pcx-0771c54d393000439"

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -24,6 +24,11 @@ variable "product_name" {
   type        = string
 }
 
+variable "tool_name" {
+  description = "(Required) The name of the tool you are deploying."
+  type        = string
+}
+
 variable "region" {
   description = "Resource region"
   type        = string

--- a/terragrunt/env/software_asset_inventory/terragrunt.hcl
+++ b/terragrunt/env/software_asset_inventory/terragrunt.hcl
@@ -8,15 +8,10 @@ dependencies {
 
 dependency "base" {
   config_path = "../base"
-
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs = {
-    cartography_repository_url = "https://12345678910.dkr.ecr.region.amazonaws.com/foo"
-  }
 }
 
 inputs = {
-  product_name                       = "security-tools-software-asset-inventory"
+  tool_name                          = "software-asset-inventory"
   dependencytrack_api_image          = "dependencytrack/apiserver"
   dependencytrack_api_image_tag      = "4.4.2@sha256:584cfd2349ec93cfde2528b8f34bd5d3a9f0a393fa38806128d646743fa649ee"
   dependencytrack_frontend_image     = "dependencytrack/frontend"

--- a/terragrunt/env/sso_proxy/terragrunt.hcl
+++ b/terragrunt/env/sso_proxy/terragrunt.hcl
@@ -8,11 +8,6 @@ dependencies {
 
 dependency "base" {
   config_path = "../base"
-
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs = {
-    cartography_repository_url = "https://12345678910.dkr.ecr.region.amazonaws.com/foo"
-  }
 }
 
 dependency "cloud_asset_inventory" {
@@ -34,7 +29,7 @@ dependency "software_asset_inventory" {
 }
 
 inputs = {
-  product_name              = "security-tools-sso-proxy"
+  tool_name                 = "sso-proxy"
   pomerium_image            = "pomerium/pomerium"
   pomerium_image_tag        = "git-74310b3d"
   pomerium_verify_image     = "pomerium/verify"


### PR DESCRIPTION
Minor change to tagging which is why there's so many files changed. Applied locally so there should be no TF plan outputs.

New additions:
- Modified dependencytrack front-end that supports credentialed cookies. Pushed locally until upstream merges my PR.
- SES setup so that tools can use SMTP if they dont support webhooks