### PR TITLE
feat: generate and upload a project's SBOM

### DIFF
--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -1,0 +1,79 @@
+name: "Generate SBOM"
+
+# Generates a CycloneDX SBOM and uploads it to Dependency-Track
+
+on:
+  workflow_call:
+    inputs:
+      project_name:
+        required: true
+        description: "Name of the Dependency-Track project"
+        type: string
+      project_type:
+        required: true
+        description: "Type of project that the SBOM is being generated for"
+        type: string        
+      project_version:
+        required: true
+        description: "Version of the Dependency-Track project"
+        type: string
+      working_directory:
+        required: true
+        description: "Directory that contains the project dependency manifest"
+        type: string
+    secrets:
+      dependency_track_api_key:
+        required: true
+      dependency_track_url:
+        required: true
+
+env:
+  BOM_REPRODUCIBLE: 1
+  CYCLONEDX_NODE: "3.9.0"
+  CYCLONEDX_PHP: "3.10.0"
+  CYCLONEDX_PYTHON: "3.2.1"
+  PROJECT_TYPES: '["node", "php", "python"]'
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate project type input
+        if: contains(fromJson(env.PROJECT_TYPES), inputs.project_type) == false
+        run: |
+          echo "Invalid project type: ${{ inputs.project_type }}. Valid types: ${{ env.TYPES }}"
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate Node SBOM
+        if: inputs.project_type == "node"
+        working-directory: ${{ inputs.working_directory }}
+        run: |
+          npm install -g @cyclonedx/bom@${{ env.CYCLONEDX_NODE }}
+          cyclonedx-node --output bom.json
+
+      - name: Generate PHP SBOM
+        if: inputs.project_type == "php"
+        working-directory: ${{ inputs.working_directory }}
+        run: |
+          composer require --dev cyclonedx/cyclonedx-php-composer:${{ env.CYCLONEDX_PHP }}
+          composer make-bom --output-format=JSON --output-file=bom.json
+
+      - name: Generate Python SBOM
+        if: inputs.project_type == "python"
+        working-directory: ${{ inputs.working_directory }}
+        run: |
+          pip install cyclonedx-bom==${{ env.CYCLONEDX_PYTHON }}
+          cyclonedx-bom --requirements --format json --output bom.json
+
+      - name: Upload SBOM
+        uses: DependencyTrack/gh-upload-sbom@801995c917fdcc580f96275837bcbe6b46e5b159 # v1.0.0
+        with:
+          serverhostname: ${{ secrets.dependency_track_url }}
+          apikey: ${{ secrets.dependency_track_api_key }}
+          autocreate: true
+          bomfilename: ${{ inputs.working_directory }}/bom.json
+          projectname: ${{ inputs.project_name }}
+          projectversion: ${{ inputs.project_version }}


### PR DESCRIPTION
# Summary 
Add a shared GitHub workflow that can be used by downstream
projects to generate and upload SBOMs to our Dependency-Track
instance.

Currently supports creating CycloneDX SBOMs in `.json` format
for Node, PHP and Python projects.

# Related
* cds-snc/platform-sre-security-support#92
* cds-snc/platform-sre-security-support#94