### PR TITLE
fix: add quotes around subnet ids

### DIFF
--- a/.github/workflows/cloud-asset-inventory-terragrunt-plan.yml
+++ b/.github/workflows/cloud-asset-inventory-terragrunt-plan.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Get current date to determine if secrets need to be rotated
         run: echo "TF_VAR_password_change_id=$(date +'%Y-%m')" >> $GITHUB_ENV
 
+      - name: Build Lambda archive
+        if: ${{ steps.filter.outputs.cloud_asset_inventory == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: terragrunt/aws/cloud_asset_inventory/src/sentinel_ingestor
+        run: |
+          ./build.sh
+
       - name: Terragrunt plan cloud_asset_inventory
         if: ${{ steps.filter.outputs.cloud_asset_inventory == 'true' || steps.filter.outputs.common == 'true' }}
         uses: cds-snc/terraform-plan@v2

--- a/terragrunt/aws/cloud_asset_inventory/lambda.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lambda.tf
@@ -2,10 +2,13 @@
 # Lambda: zip
 #
 data "archive_file" "neo4j_to_sentinel" {
-  depends_on  = [null_resource.lambda_build]
   type        = "zip"
-  source_dir  = "src/sentinel_ingestor/dist"
+  source_dir  = "${path.module}/src/sentinel_ingestor/dist"
   output_path = "/tmp/neo4j_to_sentinel.py.zip"
+
+  depends_on = [
+    null_resource.lambda_build
+  ]
 }
 
 resource "aws_lambda_function" "neo4j_to_sentinel" {

--- a/terragrunt/aws/cloud_asset_inventory/lambda.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lambda.tf
@@ -2,13 +2,10 @@
 # Lambda: zip
 #
 data "archive_file" "neo4j_to_sentinel" {
+  depends_on  = [null_resource.lambda_build]
   type        = "zip"
   source_dir  = "src/sentinel_ingestor/dist"
   output_path = "/tmp/neo4j_to_sentinel.py.zip"
-
-  depends_on = [
-    null_resource.lambda_build
-  ]
 }
 
 resource "aws_lambda_function" "neo4j_to_sentinel" {

--- a/terragrunt/aws/cloud_asset_inventory/lambda.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lambda.tf
@@ -2,9 +2,8 @@
 # Lambda: zip
 #
 data "archive_file" "neo4j_to_sentinel" {
-  type       = "zip"
-  source_dir = data.null_data_source.wait_for_lambda_exporter.outputs["source_dir"]
-
+  type        = "zip"
+  source_dir  = "${path.module}/src/sentinel_ingestor/dist"
   output_path = "/tmp/neo4j_to_sentinel.py.zip"
 }
 
@@ -59,18 +58,6 @@ resource "null_resource" "lambda_build" {
 
   provisioner "local-exec" {
     command = "${path.module}/src/sentinel_ingestor/build.sh"
-  }
-}
-
-data "null_data_source" "wait_for_lambda_exporter" {
-  inputs = {
-    # This ensures that this data resource will not be evaluated until
-    # after the null_resource has been created.
-    lambda_exporter_id = "${null_resource.lambda_build.id}"
-
-    # This value gives us something to implicitly depend on
-    # in the archive_file.
-    source_dir = "${path.module}/src/sentinel_ingestor/dist"
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/lambda.tf
+++ b/terragrunt/aws/cloud_asset_inventory/lambda.tf
@@ -2,13 +2,10 @@
 # Lambda: zip
 #
 data "archive_file" "neo4j_to_sentinel" {
-  type        = "zip"
-  source_dir  = "${path.module}/src/sentinel_ingestor/dist"
-  output_path = "/tmp/neo4j_to_sentinel.py.zip"
+  type       = "zip"
+  source_dir = data.null_data_source.wait_for_lambda_exporter.outputs["source_dir"]
 
-  depends_on = [
-    null_resource.lambda_build
-  ]
+  output_path = "/tmp/neo4j_to_sentinel.py.zip"
 }
 
 resource "aws_lambda_function" "neo4j_to_sentinel" {
@@ -62,6 +59,18 @@ resource "null_resource" "lambda_build" {
 
   provisioner "local-exec" {
     command = "${path.module}/src/sentinel_ingestor/build.sh"
+  }
+}
+
+data "null_data_source" "wait_for_lambda_exporter" {
+  inputs = {
+    # This ensures that this data resource will not be evaluated until
+    # after the null_resource has been created.
+    lambda_exporter_id = "${null_resource.lambda_build.id}"
+
+    # This value gives us something to implicitly depend on
+    # in the archive_file.
+    source_dir = "${path.module}/src/sentinel_ingestor/dist"
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
@@ -72,7 +72,7 @@
               "NetworkConfiguration": {
                 "AwsvpcConfiguration": {
                   "SecurityGroups": ["${SECURITY_GROUPS}"],
-                  "Subnets":["${SUBNETS}"]
+                  "Subnets":[${SUBNETS}]
                 }
               }
             },

--- a/terragrunt/aws/cloud_asset_inventory/state_machine.tf
+++ b/terragrunt/aws/cloud_asset_inventory/state_machine.tf
@@ -27,7 +27,7 @@ data "template_file" "asset_inventory_cartography_state_machine" {
     MIN_ECS_CAPACITY         = var.min_ecs_capacity
     MAX_ECS_CAPACITY         = var.max_ecs_capacity
     SECURITY_GROUPS          = aws_security_group.cartography.id
-    SUBNETS                  = join(", ", [for subnet in var.private_subnet_ids : format("%q", subnet)])
+    SUBNETS                  = join(", ", [for subnet in var.vpc_private_subnet_ids : format("%q", subnet)])
   }
 }
 

--- a/terragrunt/aws/cloud_asset_inventory/state_machine.tf
+++ b/terragrunt/aws/cloud_asset_inventory/state_machine.tf
@@ -27,7 +27,7 @@ data "template_file" "asset_inventory_cartography_state_machine" {
     MIN_ECS_CAPACITY         = var.min_ecs_capacity
     MAX_ECS_CAPACITY         = var.max_ecs_capacity
     SECURITY_GROUPS          = aws_security_group.cartography.id
-    SUBNETS                  = join(", ", [for subnet in var.vpc_private_subnet_ids : subnet])
+    SUBNETS                  = join(", ", [for subnet in var.private_subnet_ids : format("%q", subnet)])
   }
 }
 


### PR DESCRIPTION
Subnet ids are no longer encapsulated by quotes since the refactor due to receiving this value from a `list(string)` which is dropping the quotes.

Also tweaked the TF workflow so that the lambda dist folder is always available due to [archive files ignoring depends_on](https://github.com/hashicorp/terraform-provider-archive/issues/78)

Note: some extra changes to SSM since i updated the account list so i can run one end to end run using only my scratch account as a target