### PR TITLE
fix: change SBOM route to PUT

### DIFF
--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -49,7 +49,7 @@
       - allow:
           or:
             - http_method:
-                is: POST
+                is: PUT
 
 - from: https://api.dependencies.security.cdssandbox.xyz
   to: http://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8081


### PR DESCRIPTION
# Summary
By default, the Dependency Track `/api/v1/bom` route
is expecting a PUT request with a base64 encoded BOM.

# Related
* cds-snc/platform-sre-security-support#94