### PR TITLE
fix: Node SBOM install dependencies

### DIFF
--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -55,7 +55,8 @@ jobs:
         if: inputs.project_type == 'node'
         working-directory: ${{ inputs.working_directory }}
         run: |
-          npm install -g @cyclonedx/bom@${{ env.CYCLONEDX_NODE }}
+          npm ci 
+          npm install -g @cyclonedx/bom@${{ env.CYCLONEDX_NODE }}          
           cyclonedx-node --output bom.json
 
       - name: Generate PHP SBOM


### PR DESCRIPTION
# Summary
Fix the NodeJS generate SBOM step by installing the
dependencies before generating.

# Related
* cds-snc/platform-sre-security-support#94