### PR TITLE
fix: use function name to invoke lambda

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/state_machine.tf
+++ b/terragrunt/aws/cloud_asset_inventory/state_machine.tf
@@ -26,7 +26,7 @@ data "template_file" "asset_inventory_cartography_state_machine" {
     CARTOGRAPHY_TASK_DEF            = aws_ecs_task_definition.cartography.arn
     MIN_ECS_CAPACITY                = var.min_ecs_capacity
     MAX_ECS_CAPACITY                = var.max_ecs_capacity
-    NEO4J_SENTINEL_FORWARDER_LAMBDA = "${aws_lambda_function.neo4j_to_sentinel.arn}:$LATEST"
+    NEO4J_SENTINEL_FORWARDER_LAMBDA = aws_lambda_function.neo4j_to_sentinel.function_name
     SECURITY_GROUPS                 = aws_security_group.cartography.id
     SUBNETS                         = join(", ", [for subnet in var.vpc_private_subnet_ids : format("%q", subnet)])
   }


### PR DESCRIPTION
State machine was expecting a function name instead of an arn