### PR TITLE
fix: missing iam permissions to retrieve new ssm params

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/container_execution_role.tf
+++ b/terragrunt/aws/cloud_asset_inventory/container_execution_role.tf
@@ -94,6 +94,8 @@ data "aws_iam_policy_document" "cartography_policies" {
       aws_ssm_parameter.neo4j_auth.arn,
       aws_ssm_parameter.neo4j_password.arn,
       aws_ssm_parameter.asset_inventory_account_list.arn,
+      aws_ssm_parameter.customer_id.arn,
+      aws_ssm_parameter.shared_key.arn,
     ]
   }
 }


### PR DESCRIPTION
Missing ssm permissions for the new ECS container