### PR TITLE
feat: bump dependency track api to v4.5 to sync with frontend

### DIFF
--- a/terragrunt/env/software_asset_inventory/terragrunt.hcl
+++ b/terragrunt/env/software_asset_inventory/terragrunt.hcl
@@ -13,7 +13,7 @@ dependency "base" {
 inputs = {
   tool_name                          = "software-asset-inventory"
   dependencytrack_api_image          = "dependencytrack/apiserver"
-  dependencytrack_api_image_tag      = "4.4.2@sha256:584cfd2349ec93cfde2528b8f34bd5d3a9f0a393fa38806128d646743fa649ee"
+  dependencytrack_api_image_tag      = "4.5.0@sha256:9365f306ac54eaf1216ad8f2846062b3fe538399d8fb10a11e82be20c8c8e797"
   dependencytrack_frontend_image     = "dependencytrack/frontend"
   dependencytrack_frontend_image_tag = "4.4.0@sha256:e0b6790c19cba4470468a5cbd8eaaf80c8b9cd4c3c9be5b993032fbec5ed0daa"
   security_tools_vpc_id              = dependency.base.outputs.security_tools_vpc_id


### PR DESCRIPTION
Grabbing new enhancements that will help with reducing the noise (notifications by policy). Also necessary since the frontend was generating a error due to having access to enable the policy notifications while the backend didn't support it. Plan is empty since i applied locally to confirm the reason the front-end had the error was due to the version mismatch.