### PR TITLE
fix: allow unauthenticated PUT of a BOM

### DIFF
--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -47,9 +47,11 @@
   cors_allow_preflight: true
   policy:
       - allow:
-          or:
+          and:
             - http_method:
                 is: PUT
+            - http_path:
+                is: /api/v1/bom
 
 - from: https://api.dependencies.security.cdssandbox.xyz
   to: http://${SOFTWARE_ASSET_INVENTORY_LOAD_BALANCER_DNS}:8081


### PR DESCRIPTION
# Summary
Update the Pomerium policy to only allow an unauthenticated
PUT to Dependency-Track's BOM upload API endpoint.

# Related
* Closes #27 