### PR TITLE
feat: add `yarn install` to generate-sbom action

### DIFF
--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -29,14 +29,14 @@ inputs:
   working_directory:
     description: "Directory that contains the project dependency manifest"
     required: false
-    default: "."    
+    default: "."
 
 runs:
   using: "composite"
   steps:
     - name: Fail if unsupported project type
       env:
-        PROJECT_TYPES: '["docker", "node", "php", "python"]'    
+        PROJECT_TYPES: '["docker", "node", "php", "python"]'
       if: contains(fromJson(env.PROJECT_TYPES), inputs.project_type) == false
       run: |
         echo "Invalid project type: ${{ inputs.project_type }}. Valid types: ${{ env.PROJECT_TYPES }}"
@@ -56,18 +56,22 @@ runs:
     - name: Generate Node SBOM
       env:
         BOM_REPRODUCIBLE: "1"
-        CYCLONEDX_NODE: "3.9.0"    
+        CYCLONEDX_NODE: "3.9.0"
       if: inputs.project_type == 'node'
       working-directory: ${{ inputs.working_directory }}
       run: |
-        npm ci
+        if [ -f "yarn.lock" ]; then
+            yarn install
+        else
+            npm ci
+        fi
         npm install -g @cyclonedx/bom@${{ env.CYCLONEDX_NODE }}
         cyclonedx-node --output bom.json
       shell: bash
 
     - name: Generate PHP SBOM
       env:
-        CYCLONEDX_PHP: "3.10.0"    
+        CYCLONEDX_PHP: "3.10.0"
       if: inputs.project_type == 'php'
       working-directory: ${{ inputs.working_directory }}
       run: |
@@ -78,7 +82,7 @@ runs:
 
     - name: Generate Python SBOM
       env:
-        CYCLONEDX_PYTHON: "3.2.1"    
+        CYCLONEDX_PYTHON: "3.2.1"
       if: inputs.project_type == 'python'
       working-directory: ${{ inputs.working_directory }}
       run: |


### PR DESCRIPTION
# Summary
Supports projects that use a yarn to manage their dependencies.
If a `yarn.lock` file exists, `yarn install` will be used, otherwise
default to using `npm ci` to install packages.

# Related
* cds-snc/platform-sre-security-support#94