### PR TITLE
feat: allow POST to Dependency-Track /api/v1/bom

### DIFF
--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -49,6 +49,7 @@
       - allow:
           and:
             - http_method:
+                is: POST
                 is: PUT
             - http_path:
                 is: /api/v1/bom


### PR DESCRIPTION
# Summary
Add in POST as an allowed HTTP method when uploading a BOM
to Dependency-Track through the API.

This is being done to test if a curl of the `bom.json` is faster
than the GitHub action that uses PUT with a base64 encoded
string of the `bom.json` contents.

# Related
* cds-snc/platform-sre-security-support#94