### PR TITLE
fix: Dependency-Track BOM route policy

### DIFF
--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -50,11 +50,9 @@
           or:
             - http_method:
                 is: POST
-            - http_path:
-                is: /api/v1/bom
-          or:
             - http_method:
                 is: PUT
+          and:
             - http_path:
                 is: /api/v1/bom
 

--- a/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
+++ b/terragrunt/aws/sso_proxy/configs/routes.yml.tmpl
@@ -47,9 +47,13 @@
   cors_allow_preflight: true
   policy:
       - allow:
-          and:
+          or:
             - http_method:
                 is: POST
+            - http_path:
+                is: /api/v1/bom
+          or:
+            - http_method:
                 is: PUT
             - http_path:
                 is: /api/v1/bom


### PR DESCRIPTION
# Summary
The double `is` syntax is not supported for a string matcher field.

# Related
* #32 