### PR TITLE
feat: retry when ecs task fails due to no capacity

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
@@ -65,6 +65,14 @@
                 }
               }
             },
+            "Retry": [
+              {
+                "ErrorEquals": ["ECS.AmazonECSException"],
+                "IntervalSeconds": 300,
+                "BackoffRate": 2.0,
+                "MaxAttempts": 4
+              }
+            ],
             "End": true
           }
         }

--- a/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/state-machines/cartography.json.tmpl
@@ -73,6 +73,11 @@
                 "MaxAttempts": 4
               }
             ],
+            "Catch": [{"ErrorEquals": [ "States.ALL" ], "ResultPath": null, "Next": "Handle Failure"}],
+            "End": true
+          },
+          "Handle Failure": {
+            "Type": "Pass",
             "End": true
           }
         }


### PR DESCRIPTION
Friday's run failed due to ECS Fargate not having capacity at the moment in all 3 availability zones we're running in. I'm adding a retry mechanism with a backoff rate to retry in the hopes that capacity becomes available by the fourth try at the latest.

Also adding the ability to skip a account scan if it errors out instead of failing the entire state machine.

![image](https://user-images.githubusercontent.com/85885638/171001214-cf2940f7-30d9-4b76-b9ee-ff284e997a78.png)
