### PR TITLE
refactor: use user inputted passwords for neo4j

### DIFF
--- a/.github/workflows/cloud-asset-inventory-terragrunt-apply.yml
+++ b/.github/workflows/cloud-asset-inventory-terragrunt-apply.yml
@@ -17,6 +17,7 @@ env:
   TERRAGRUNT_VERSION: 0.36.7
   TF_INPUT: false
   TF_VAR_customer_id: ${{ secrets.TF_VARS_LOG_ANALYTICS_CUSTOMER_ID }}
+  TF_VAR_neo4j_password: ${{ secrets.TF_VARS_NEO4J_SECRETS_PASSWORD }}
   TF_VAR_shared_key: ${{ secrets.TF_VARS_LOG_ANALYTICS_SHARED_KEY }}
 
 permissions:

--- a/.github/workflows/cloud-asset-inventory-terragrunt-plan.yml
+++ b/.github/workflows/cloud-asset-inventory-terragrunt-plan.yml
@@ -16,6 +16,7 @@ env:
   TERRAGRUNT_VERSION: 0.36.7
   TF_INPUT: false
   TF_VAR_customer_id: ${{ secrets.TF_VARS_LOG_ANALYTICS_CUSTOMER_ID }}
+  TF_VAR_neo4j_password: ${{ secrets.TF_VARS_NEO4J_SECRETS_PASSWORD }}
   TF_VAR_shared_key: ${{ secrets.TF_VARS_LOG_ANALYTICS_SHARED_KEY }}
 
 

--- a/terragrunt/aws/cloud_asset_inventory/inputs.tf
+++ b/terragrunt/aws/cloud_asset_inventory/inputs.tf
@@ -25,6 +25,12 @@ variable "neo4j_image_tag" {
   type        = string
 }
 
+variable "neo4j_password" {
+  description = "(Required) The neo4j password"
+  sensitive   = true
+  type        = string
+}
+
 variable "password_change_id" {
   description = "(Required) Id to trigger changing the neo4j password."
   type        = string


### PR DESCRIPTION
Neo4J doesn't support changing passwords via environment variable. The `NEO4J_AUTH` variable is used to set the initial password. Afterwards users have to issue the `:server change-password` command to change the password.

This PR refactors Neo4j authentication so that it uses a GitHub secret as the source for the password since it'll be up to admins to change the password when necessary.