### PR TITLE
fix: CSP purge lambda IAM permissions

### DIFF
--- a/terragrunt/aws/csp_violation_report_service/iam_lambda.tf
+++ b/terragrunt/aws/csp_violation_report_service/iam_lambda.tf
@@ -21,6 +21,7 @@ data "aws_iam_policy_document" "purge_csp_reports_lambda_policies" {
 
     actions = [
       "ssm:DescribeParameters",
+      "ssm:GetParameter",
       "ssm:GetParameters",
     ]
     resources = [


### PR DESCRIPTION
# Summary
Update the CSP purge lambda to allow it to retrieve single parameters
because no matter how many times I've done it in the past, I will continue
to start off with `ssm:GetParameters` in all my IAM policies until the end
of time.