### PR TITLE
fix: increase original policy column length

### DIFF
--- a/images/csp_violation_report_service/app/databases/migrations/2022_08_22_171230_increase_column_length.py
+++ b/images/csp_violation_report_service/app/databases/migrations/2022_08_22_171230_increase_column_length.py
@@ -1,0 +1,19 @@
+"""IncreaseColumnLength Migration."""
+
+from masoniteorm.migrations import Migration
+
+
+class IncreaseColumnLength(Migration):
+    def up(self):
+        """
+        Run the migrations.
+        """
+        with self.schema.table("reports") as table:
+            table.string("original_policy", length=8190).change()
+
+    def down(self):
+        """
+        Revert the migrations.
+        """
+        with self.schema.table("reports") as table:
+            table.string("original_policy").change()


### PR DESCRIPTION
the `original-policy` column in the reports table is currently set to the masonite orm default of 255 for varchar fields. Since CSP headers are dynamic i'm increasing this column to the default maximum header length of `8190` used by apache and other web framework/servers.

Debugged a error 500 when this was integrated with Notify and realized the error was related to not being able to store the original policy in the db.
![image](https://user-images.githubusercontent.com/85885638/185983404-1db028cb-ea01-49e4-89e7-f19f5093a2ed.png)
