### PR TITLE
fix: bumping the connection version to an existing

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           aws lambda get-layer-version-by-arn \
           --region ca-central-1 \
-          --arn arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:6 \
+          --arn arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:8 \
           | jq -r '.Content.Location' \
           | xargs curl -o connector.zip    
 


### PR DESCRIPTION
# Summary | Résumé

To fix the issue with the step 'Retrieve Sentinel connector layer' trying to reach to a version that does not exist anymore. 

