### PR TITLE
fix: remove special characters with shell meanings

### DIFF
--- a/terragrunt/aws/software_asset_inventory/ssm.tf
+++ b/terragrunt/aws/software_asset_inventory/ssm.tf
@@ -4,7 +4,7 @@ resource "random_password" "dependencytrack_db_password" {
   lower            = true
   upper            = true
   special          = true
-  override_special = "%*()-_{}<>" # Allowed special characters that dont overlap with ip address and http RFC's
+  override_special = "%-_" # Allowed special characters that dont overlap with ip address and http RFC's
 
   min_lower   = 1
   min_upper   = 1


### PR DESCRIPTION
# Summary
Update the random password's allow special characters to remove any
that can be interpreted by a shell.   

The theory we have is that since the database password is being passed
as an environment variable, there's a chance that special characters 
are causing it to be truncated unexpectedly.

# Summary
- #83 