### PR TITLE
fix: Dependency Track auth using database URL

### DIFF
--- a/terragrunt/aws/software_asset_inventory/api_server.tf
+++ b/terragrunt/aws/software_asset_inventory/api_server.tf
@@ -32,9 +32,7 @@ data "template_file" "dependencytrack_api_container_definition" {
   template = file("container-definitions/dependencytrack_api.json.tmpl")
 
   vars = {
-    ALPINE_DATABASE_URL          = "jdbc:postgresql://${module.dependencytrack_db.proxy_endpoint}:5432/dtrack"
-    ALPINE_DATABASE_USERNAME     = aws_ssm_parameter.dependencytrack_db_user.arn
-    ALPINE_DATABASE_PASSWORD     = aws_ssm_parameter.dependencytrack_db_password.arn
+    ALPINE_DATABASE_URL          = aws_ssm_parameter.dependencytrack_db_url.arn
     AWS_LOGS_GROUP               = aws_cloudwatch_log_group.dependencytrack_api.name
     AWS_LOGS_REGION              = var.region
     AWS_LOGS_STREAM_PREFIX       = "${local.dependencytrack_api_service_name}-task"

--- a/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
+++ b/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
@@ -8,10 +8,6 @@
         "value" : "external"
       },
       {
-        "name" : "ALPINE_DATABASE_URL",
-        "value" : "${ALPINE_DATABASE_URL}"
-      },
-      {
         "name" : "ALPINE_DATABASE_DRIVER",
         "value" : "org.postgresql.Driver"
       },
@@ -21,23 +17,7 @@
       },
       {
         "name" : "ALPINE_DATABASE_POOL_ENABLED",
-        "value" : "true"
-      },
-      {
-        "name" : "ALPINE_DATABASE_POOL_MAX_SIZE",
-        "value" : "20"
-      },
-      {
-        "name" : "ALPINE_DATABASE_POOL_MIN_IDLE",
-        "value" : "10"
-      },
-      {
-        "name" : "ALPINE_DATABASE_POOL_IDLE_TIMEOUT",
-        "value" : "300000"
-      },
-      {
-        "name" : "ALPINE_DATABASE_POOL_MAX_LIFETIME",
-        "value" : "600000"
+        "value" : "false"
       },
       {
         "name" : "ALPINE_CORS_ENABLED",
@@ -90,12 +70,8 @@
     ],
     "secrets" : [
       {
-        "name" : "ALPINE_DATABASE_USERNAME",
-        "valueFrom" : "${ALPINE_DATABASE_USERNAME}"
-      },
-      {
-        "name" : "ALPINE_DATABASE_PASSWORD",
-        "valueFrom" : "${ALPINE_DATABASE_PASSWORD}"
+        "name" : "ALPINE_DATABASE_URL",
+        "valueFrom" : "${ALPINE_DATABASE_URL}"
       }
     ]
   }

--- a/terragrunt/aws/software_asset_inventory/container_execution_role_api.tf
+++ b/terragrunt/aws/software_asset_inventory/container_execution_role_api.tf
@@ -72,8 +72,7 @@ data "aws_iam_policy_document" "dependencytrack_api_policies" {
       "ssm:GetParameters",
     ]
     resources = [
-      aws_ssm_parameter.dependencytrack_db_password.arn,
-      aws_ssm_parameter.dependencytrack_db_user.arn,
+      aws_ssm_parameter.dependencytrack_db_url.arn,
     ]
   }
 

--- a/terragrunt/aws/software_asset_inventory/ssm.tf
+++ b/terragrunt/aws/software_asset_inventory/ssm.tf
@@ -40,3 +40,15 @@ resource "aws_ssm_parameter" "dependencytrack_db_user" {
     Product               = "${var.product_name}-${var.tool_name}"
   }
 }
+
+resource "aws_ssm_parameter" "dependencytrack_db_url" {
+  name  = "/${var.ssm_prefix}/dependencytrack_db_url"
+  type  = "SecureString"
+  value = "jdbc:${module.dependencytrack_db.proxy_connection_string_value}"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = "${var.product_name}-${var.tool_name}"
+  }
+}


### PR DESCRIPTION
# Summary
Update the Dependency Track container definition to authenticate using the RDS proxy connection string.

Also disables database pooling since this is managed by the RDS proxy.

# Related
- #83 