### PR TITLE
fix: ssl=true parameter not required

### DIFF
--- a/terragrunt/aws/software_asset_inventory/ssm.tf
+++ b/terragrunt/aws/software_asset_inventory/ssm.tf
@@ -40,7 +40,7 @@ resource "aws_ssm_parameter" "dependencytrack_db_user" {
 resource "aws_ssm_parameter" "dependencytrack_db_url" {
   name  = "/${var.ssm_prefix}/dependencytrack_db_url"
   type  = "SecureString"
-  value = "jdbc:postgresql://${module.dependencytrack_db.proxy_endpoint}:5432/dtrack?user=${aws_ssm_parameter.dependencytrack_db_user.value}&password=${aws_ssm_parameter.dependencytrack_db_password.value}&ssl=true"
+  value = "jdbc:postgresql://${module.dependencytrack_db.proxy_endpoint}:5432/dtrack?user=${aws_ssm_parameter.dependencytrack_db_user.value}&password=${aws_ssm_parameter.dependencytrack_db_password.value}"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value


### PR DESCRIPTION
# Summary
Remove the `ssl=true` URL parameter from the JDBC connection string.

# Related
- #83 