### PR TITLE
feat: add JSON lint workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Terraform",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": "..",
+    "context": ".."
   },
   "containerEnv": {
     "SHELL": "/bin/zsh",
@@ -27,13 +27,11 @@
       "version": "2.5.6"
     }
   },
-  // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
     "hashicorp.terraform",
     "redhat.vscode-yaml",
     "sebastianbille.iam-legend",
-    "GitHub.copilot",
+    "GitHub.copilot"
   ],
-  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode"
 }

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,0 +1,29 @@
+name: JSON lint
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**/*.json"
+      - "**/*.json.tmpl"
+      - ".github/workflows/json-lint.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.json"
+      - "**/*.json.tmpl"
+      - ".github/workflows/json-lint.yml"
+
+jobs:
+  json-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+
+      - name: Lint JSON
+        run: find . -name "*.json" -exec cat {} \; | jq .
+
+      - name: Lint JSON templates
+        run: find . -name "*.json.tmpl" -exec cat {} \; | sed "s/\${[^}]*}//g" | jq . # remove ${} placeholders


### PR DESCRIPTION
# Summary
Add a workflow that lints all project JSON and JSON templates for errors.  This will help catch `terraform apply` errors that aren't always surfaced in a plan.

# Related
- #92 
- #93