### PR TITLE
chore: upgrade Dependency-Track api and frontend

### DIFF
--- a/terragrunt/aws/software_asset_inventory/frontend.tf
+++ b/terragrunt/aws/software_asset_inventory/frontend.tf
@@ -35,7 +35,7 @@ data "template_file" "dependencytrack_frontend_container_definition" {
     AWS_LOGS_GROUP                        = aws_cloudwatch_log_group.dependencytrack_frontend.name
     AWS_LOGS_REGION                       = var.region
     AWS_LOGS_STREAM_PREFIX                = "${local.dependencytrack_frontend_service_name}-task"
-    DEPENDENCYTRACK_FRONTEND_IMAGE        = "794722365809.dkr.ecr.ca-central-1.amazonaws.com/security-tools/software_asset_inventory/dependencytrack_frontend:latest"
+    DEPENDENCYTRACK_FRONTEND_IMAGE        = "${var.dependencytrack_frontend_image}:${var.dependencytrack_frontend_image_tag}"
     DEPENDENCYTRACK_FRONTEND_SERVICE_NAME = local.dependencytrack_frontend_service_name
   }
 }

--- a/terragrunt/env/software_asset_inventory/terragrunt.hcl
+++ b/terragrunt/env/software_asset_inventory/terragrunt.hcl
@@ -13,9 +13,9 @@ dependency "base" {
 inputs = {
   tool_name                          = "software-asset-inventory"
   dependencytrack_api_image          = "dependencytrack/apiserver"
-  dependencytrack_api_image_tag      = "4.5.0@sha256:9365f306ac54eaf1216ad8f2846062b3fe538399d8fb10a11e82be20c8c8e797"
+  dependencytrack_api_image_tag      = "4.6.1@sha256:54a44aab50129bcf0ae3dbeea2508870b48af132969a6929f0a75c772db7079b"
   dependencytrack_frontend_image     = "dependencytrack/frontend"
-  dependencytrack_frontend_image_tag = "4.4.0@sha256:e0b6790c19cba4470468a5cbd8eaaf80c8b9cd4c3c9be5b993032fbec5ed0daa"
+  dependencytrack_frontend_image_tag = "4.6.0@sha256:a525d909ecf6cecf4a0302a95b406e494ae155a9a148be019ab93f1d5f7c415d"
   security_tools_vpc_id              = dependency.base.outputs.security_tools_vpc_id
   vpc_private_subnet_cidrs           = dependency.base.outputs.vpc_private_subnet_cidrs
   vpc_public_subnet_cidrs            = dependency.base.outputs.vpc_public_subnet_cidrs


### PR DESCRIPTION
# Summary
Upgrade to latest API and frontend containers for Dependency-Track. Testing if this will resolve the intermittent 500 errors we've noticed trying to login.

Also switches back to official D-Track frontend image now that @mohamed-cds's upstream PR merged.

# Related
- DependencyTrack/frontend#149