### PR TITLE
fix: re-enable Dependency-Track database pooling

### DIFF
--- a/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
+++ b/terragrunt/aws/software_asset_inventory/container-definitions/dependencytrack_api.json.tmpl
@@ -21,7 +21,23 @@
       },
       {
         "name" : "ALPINE_DATABASE_POOL_ENABLED",
-        "value" : "false"
+        "value" : "true"
+      },
+      {
+        "name" : "ALPINE_DATABASE_POOL_MAX_SIZE",
+        "value" : "20"
+      },
+      {
+        "name" : "ALPINE_DATABASE_POOL_MIN_IDLE",
+        "value" : "10"
+      },
+      {
+        "name" : "ALPINE_DATABASE_POOL_IDLE_TIMEOUT",
+        "value" : "300000"
+      },
+      {
+        "name" : "ALPINE_DATABASE_POOL_MAX_LIFETIME",
+        "value" : "600000"
       },
       {
         "name" : "ALPINE_CORS_ENABLED",


### PR DESCRIPTION
# Summary
This was removed in a previous commit thinking that RDS proxy would be able to handle all database connection pooling, but it is likely causing issues with how Dependency-Track is trying to perform multiple database queries at once and leading to I/O errors and failures to connect to the proxy.

# Related
- #85 
- #105