### PR TITLE
fixing action

### DIFF
--- a/.github/actions/docker-scan/action.yml
+++ b/.github/actions/docker-scan/action.yml
@@ -86,7 +86,8 @@ runs:
         output: 'trivy-results.sarif'
 
     - name: upload trivy scan results to github security tab
-      if: inputs.upload_docker_vulns == 'true'uses: github/codeql-action/upload-sarif@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
+      if: inputs.upload_docker_vulns == 'true'
+      uses: github/codeql-action/upload-sarif@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
       with:
         sarif_file: 'trivy-results.sarif'
         token: ${{ inputs.token }}

--- a/.github/actions/docker-scan/action.yml
+++ b/.github/actions/docker-scan/action.yml
@@ -11,42 +11,56 @@ inputs:
   token:
     description: "Token for allowing the action to post in the security tab"
     required: true
+  upload_docker_vulns:
+    description: "Flag to specify vulnerabilities upload"
+    required: false
+    default: true
 
 runs:
   using: "composite"
-  steps:
+  steps:      
+    - name: Re-tag docker image
+      run: |
+        docker tag ${{ inputs.docker_image }} ${{ inputs.sbom_name }}
+      shell: bash
+
     - name: Install Trivy
       run: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.34.0
       shell: bash
 
     - name: run trivy docker
+      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
       run: |
         trivy image \
           --format github \
           --vuln-type os,library \
           --security-checks vuln \
           --output dependency-results.sbom.json \
-          ${{ inputs.docker_image }}
+          ${{ inputs.sbom_name }}
       shell: bash
 
     - name: replace apk with alpine
+      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
       run: |
         sed -i 's/pkg:apk/pkg:alpine/g' dependency-results.sbom.json
       shell: bash
 
     - name: replace correlator
+      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
       run: |
         cat dependency-results.sbom.json | jq '.job.correlator = "${{ inputs.sbom_name }}"' > sbom.tmp 
         mv sbom.tmp dependency-results.sbom.json
       shell: bash
 
     - name: add mask to token
+      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
       run: |
         echo "::add-mask::${{ inputs.token }}"
       shell: bash
     
     - name: upload sbom to github
+      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
       run: |
         curl \
           -H 'Accept: application/vnd.github+json' \
@@ -57,12 +71,14 @@ runs:
 
     - name: run docker vulnerability scanner
       uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5
+      if: inputs.upload_docker_vulns == 'true'
       with:
-        image-ref: '${{ inputs.docker_image }}'
+        image-ref: '${{ inputs.sbom_name }}'
         format: 'sarif'
         output: 'trivy-results.sarif'
 
     - name: upload trivy scan results to github security tab
+      if: inputs.upload_docker_vulns == 'true'
       uses: github/codeql-action/upload-sarif@678fc3afe258fb2e0cdc165ccf77b85719de7b3c # v2.1.33
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/actions/docker-scan/action.yml
+++ b/.github/actions/docker-scan/action.yml
@@ -16,9 +16,17 @@ inputs:
     required: false
     default: true
 
+env:
+  upload_sbom: true
+
 runs:
   using: "composite"
-  steps:      
+  steps:
+    - name: Set upload_sbom variable
+      run: |
+        echo "upload_sbom=${{ github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}" >> $GITHUB_ENV
+      shell: bash
+
     - name: Re-tag docker image
       run: |
         docker tag ${{ inputs.docker_image }} ${{ inputs.sbom_name }}
@@ -30,7 +38,7 @@ runs:
       shell: bash
 
     - name: run trivy docker
-      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
+      if: env.upload_sbom == 'true'
       run: |
         trivy image \
           --format github \
@@ -41,26 +49,26 @@ runs:
       shell: bash
 
     - name: replace apk with alpine
-      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
+      if: env.upload_sbom == 'true'
       run: |
         sed -i 's/pkg:apk/pkg:alpine/g' dependency-results.sbom.json
       shell: bash
 
     - name: replace correlator
-      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
+      if: env.upload_sbom == 'true'
       run: |
         cat dependency-results.sbom.json | jq '.job.correlator = "${{ inputs.sbom_name }}"' > sbom.tmp 
         mv sbom.tmp dependency-results.sbom.json
       shell: bash
 
     - name: add mask to token
-      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
+      if: env.upload_sbom == 'true'
       run: |
         echo "::add-mask::${{ inputs.token }}"
       shell: bash
     
     - name: upload sbom to github
-      if: github.event_name == 'push' && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref
+      if: env.upload_sbom == 'true'
       run: |
         curl \
           -H 'Accept: application/vnd.github+json' \


### PR DESCRIPTION
# Summary | Résumé

- Creation of a variable to define if we would like to upload the vulnerabilities scan result to GitHub Security. When we rollout, the idea is that we would start not uploading the results to not overwhelm teams. If nothing is passed to this input, upload the results is going to happen by default.
- Retag the docker image to increase readability and easier relate to the image being scanned.
- Changes with sbom upload. We only want to submit the software bill of material when there is a push to the default branch. 