### PR TITLE
fix: add missing permissions

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -7,6 +7,7 @@ env:
   REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/security-tools
 
 permissions:
+  id-token: write
   security-events: write
   contents: write
   actions: read


### PR DESCRIPTION
# Summary
Workflow token write permission is needed for OIDC.

# Related
- cds-snc/platform-core-services#209