### PR TITLE
feat: update generate SBOM to post to GitHub

### DIFF
--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -1,104 +1,64 @@
-name: "Generate SBOM"
-description: "Generates a CycloneDX SBOM and uploads it to Dependency-Track"
+name: "Generate Docker SBOM"
+description: "Generates a Docker SBOM and uploads it to GitHub's asset inventory"
 
 inputs:
-  dependency_track_api_key:
-    description: "API key for Dependency-Track used to upload the SBOM"
-    required: true
-  dependency_track_url:
-    description: "URL of the Dependency-Track instance used to upload the SBOM"
-    required: false
-    default: https://sbom.dependencies.security.cdssandbox.xyz
   docker_image:
     description: "The Docker image and tag used to generate the SBOM"
-    required: false
-  in_file:
-    description: "Input file used to generate the Python SBOM"
-    required: false
-    default: "requirements.txt"
-  project_name:
-    description: "Name of the Dependency-Track project"
     required: true
-  project_type:
-    description: "Type of project that the SBOM is being generated for"
+  dockerfile_path:
+    description: "The path to the Dockerfile being scanned"
     required: true
-  project_version:
-    description: "Version of the Dependency-Track project"
-    required: false
-    default: "main"
-  working_directory:
-    description: "Directory that contains the project dependency manifest"
-    required: false
-    default: "."
+  sbom_name:
+    description: "The name of the SBOM"
+    required: true
+  token:
+    description: "Token for allowing the action to post in the security tab"
+    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Fail if unsupported project type
+    - name: Install Trivy
       env:
-        PROJECT_TYPES: '["docker", "node", "php", "python"]'
-      if: contains(fromJson(env.PROJECT_TYPES), inputs.project_type) == false
+        TRIVY_VERSION: "v0.34.0"
       run: |
-        echo "Invalid project type: ${{ inputs.project_type }}. Valid types: ${{ env.PROJECT_TYPES }}"
-        exit 1
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | \
+          sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}}
       shell: bash
 
-    - name: Generate Docker SBOM
-      env:
-        SYFT_VERSION: "v0.46.2"
-      if: inputs.project_type == 'docker'
-      working-directory: ${{ inputs.working_directory }}
+    - name: Re-tag docker image
       run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin ${{ env.SYFT_VERSION }}
-        syft ${{ inputs.docker_image }} --output cyclonedx-json --file bom.json
+        docker tag ${{ inputs.docker_image }} ${{ inputs.sbom_name }}
       shell: bash
 
-    - name: Generate Node SBOM
-      env:
-        BOM_REPRODUCIBLE: "1"
-        CYCLONEDX_NODE: "3.9.0"
-      if: inputs.project_type == 'node'
-      working-directory: ${{ inputs.working_directory }}
+    - name: Trivy scan
       run: |
-        if [ -f "yarn.lock" ]; then
-            yarn install
-        else
-            npm ci
-        fi
-        npm install -g @cyclonedx/bom@${{ env.CYCLONEDX_NODE }}
-        cyclonedx-node --output bom.json
+        trivy image \
+          --format github \
+          --vuln-type os,library \
+          --security-checks vuln \
+          --output dependency-results.sbom.json \
+          ${{ inputs.sbom_name }}
       shell: bash
 
-    - name: Generate PHP SBOM
-      env:
-        CYCLONEDX_PHP: "3.10.0"
-      if: inputs.project_type == 'php'
-      working-directory: ${{ inputs.working_directory }}
+    - name: SBOM fix - update apk package type to alpine
       run: |
-        composer global config allow-plugins.cyclonedx/cyclonedx-php-composer true --no-interaction
-        composer global require --dev cyclonedx/cyclonedx-php-composer:${{ env.CYCLONEDX_PHP }}
-        composer make-bom --output-format=JSON --output-file=bom.json
+        sed -i 's/pkg:apk/pkg:alpine/g' dependency-results.sbom.json
       shell: bash
 
-    - name: Generate Python SBOM
-      env:
-        CYCLONEDX_PYTHON: "3.10.1"
-      if: inputs.project_type == 'python'
-      working-directory: ${{ inputs.working_directory }}
+    - name: SBOM fix - group scans with correlator and set Dockerfile path
       run: |
-        pip install cyclonedx-bom==${{ env.CYCLONEDX_PYTHON }}
-        cyclonedx-bom --requirements --in-file ${{ inputs.in_file }} --format json --output bom.json
+        cat dependency-results.sbom.json | \
+          jq '.job.correlator = "${{ inputs.sbom_name }}"' | \
+          jq '.manifests[] += {"file":{"source_location": "${{ inputs.dockerfile_path }}"}}' > sbom.tmp
+        mv sbom.tmp dependency-results.sbom.json
       shell: bash
 
     - name: Upload SBOM
-      working-directory: ${{ inputs.working_directory }}
       run: |
-        echo "::add-mask::${{ inputs.dependency_track_api_key }}"
-        curl -sS -X "POST" "${{ inputs.dependency_track_url }}/api/v1/bom" \
-            -H "Content-Type: multipart/form-data" \
-            -H "X-Api-Key: ${{ inputs.dependency_track_api_key }}" \
-            -F "autoCreate=true" \
-            -F "projectName=${{ inputs.project_name }}" \
-            -F "projectVersion=${{ inputs.project_version }}" \
-            -F "bom=@bom.json" > /dev/null
+        curl \
+          -H 'Accept: application/vnd.github+json' \
+          -H 'Authorization: token ${{ inputs.token }}' \
+          'https://api.github.com/repos/'$GITHUB_REPOSITORY'/dependency-graph/snapshots' \
+          -d @dependency-results.sbom.json
       shell: bash

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -20,10 +20,10 @@ runs:
   steps:
     - name: Install Trivy
       env:
-        TRIVY_VERSION: "v0.34.0"
+        TRIVY_VERSION: "v0.36.0"
       run: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | \
-          sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}}
+          sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
       shell: bash
 
     - name: Re-tag docker image


### PR DESCRIPTION
# Summary
Update the generate SBOM action that so that it only creates Docker SBOMs and posts them to GitHub's asset inventory.

The asset inventory for other manifest types are now automatically created by GitHub.

# Related
- #172