### PR TITLE
fix: update Trivy scan timeout to 15 minutes

### DIFF
--- a/.github/actions/docker-scan/action.yml
+++ b/.github/actions/docker-scan/action.yml
@@ -20,6 +20,8 @@ runs:
       with:
         image-ref: "${{ inputs.docker_image }}"
         format: "sarif"
+        security-checks: "vuln"
+        timeout: "15m"
         output: "trivy-results.sarif"
 
     - name: Update sarif vulnerability locations

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -37,6 +37,7 @@ runs:
           --format github \
           --vuln-type os,library \
           --security-checks vuln \
+          --timeout 15m \
           --output dependency-results.sbom.json \
           ${{ inputs.sbom_name }}
       shell: bash


### PR DESCRIPTION
# Summary
Trivy scan is timing out on larger images with its default 5 minute timeout.

Also limit the Docker scan to only check for vulnerabilities.

# Related
- cds-snc/platform-core-services#204