### PR TITLE
fix: pull Docker image before re-tag

### DIFF
--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -32,6 +32,7 @@ runs:
 
     - name: Re-tag docker image
       run: |
+        docker pull ${{ inputs.docker_image }} --platform ${{ inputs.platform }}
         docker tag ${{ inputs.docker_image }} ${{ inputs.sbom_name }}
       shell: bash
 


### PR DESCRIPTION
# Summary
Update the re-tag step to pull down the Docker image of the request architecture before attempting to re-tag.

This fixes the error of the `docker tag` command reporting that the image does not exist.