### PR TITLE
fix: set permission to describe all ec2

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/container_execution_role.tf
+++ b/terragrunt/aws/cloud_asset_inventory/container_execution_role.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "cartography_policies" {
     effect = "Allow"
 
     actions = [
-      "ec2:DescribeRegions",
+      "ec2:Describe*",
     ]
     resources = [
       "*"


### PR DESCRIPTION
# Summary | Résumé

Switching permission to allow describe all EC2 resources for Catography