### PR TITLE
chore: upgrade CSP violation DB cluster

### DIFF
--- a/terragrunt/aws/csp_violation_report_service/rds.tf
+++ b/terragrunt/aws/csp_violation_report_service/rds.tf
@@ -4,7 +4,7 @@ module "csp_reports_db" {
 
   database_name  = aws_ssm_parameter.db_database.value
   engine         = "aurora-postgresql"
-  engine_version = "13.6"
+  engine_version = "13.9"
   instances      = 2
   instance_class = "db.t3.medium"
   username       = aws_ssm_parameter.db_username.value


### PR DESCRIPTION
# Summary
Upgrade to latest 13.x Aurora Postgres minor version available for the CSP report violation service.