### PR TITLE
fix: requires public IP assigned

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/cloudwatch_event.tf
+++ b/terragrunt/aws/cloud_asset_inventory/cloudwatch_event.tf
@@ -17,8 +17,9 @@ resource "aws_cloudwatch_event_target" "cloudquery" {
     task_definition_arn = aws_ecs_task_definition.cloudquery.arn
     launch_type         = "FARGATE"
     network_configuration {
-      subnets         = var.vpc_private_subnet_ids
-      security_groups = [aws_security_group.cloudquery.id]
+      subnets          = var.vpc_private_subnet_ids
+      security_groups  = [aws_security_group.cloudquery.id]
+      assign_public_ip = true
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

The cron job setup was missing a public IP assigned. I tested a few different combinations and in order for the ECS task to run properly, it requires the dedicated security group we created but also the Public IP.
