### PR TITLE
fix: change CQ destination file format to JSON

### DIFF
--- a/images/cloud_asset_inventory/cloudquery/Dockerfile
+++ b/images/cloud_asset_inventory/cloudquery/Dockerfile
@@ -1,6 +1,5 @@
 FROM ghcr.io/cloudquery/cloudquery:latest@sha256:7fac67fd0d9a30aa966993d813107b6e862a8820da16fac54f7be52c837a3afc
 
 COPY config.yml /app
-COPY find_denied_permissions.sh /app
 
 CMD [ "sync", "--log-console", "--log-level", "debug","./config.yml"]

--- a/images/cloud_asset_inventory/cloudquery/config.yml
+++ b/images/cloud_asset_inventory/cloudquery/config.yml
@@ -42,5 +42,5 @@ spec:
   spec:
     bucket: ${CQ_S3_BUCKET}
     region: "ca-central-1"
-    path: "cloudquery/{{TABLE}}/{{YEAR}}-{{MONTH}}-{{DAY}}-{{HOUR}}-{{MINUTE}}/{{UUID}}.parquet"
+    path: "cloudquery/{{TABLE}}/{{YEAR}}-{{MONTH}}-{{DAY}}-{{HOUR}}-{{MINUTE}}/{{UUID}}.json"
     format: "json"

--- a/images/cloud_asset_inventory/cloudquery/config.yml
+++ b/images/cloud_asset_inventory/cloudquery/config.yml
@@ -3,7 +3,6 @@ spec:
   name: aws
   path: cloudquery/aws
   version: "v15.4.0"
-  # tables: ["aws_s3*"]
   tables: ["*"]
   skip_tables:
   - aws_ec2_vpc_endpoint_services # this resource includes services that are available from AWS as well as other AWS Accounts
@@ -40,11 +39,8 @@ spec:
   path: "cloudquery/s3"
   version: "v3.1.0"
   write_mode: "append" # s3 only supports 'append' mode
-  # batch_size: 10000 # optional
-  # batch_size_bytes: 5242880 # optional
   spec:
     bucket: ${CQ_S3_BUCKET}
     region: "ca-central-1"
-    path: "cloudquery/{{TABLE}}/dt={{YEAR}}-{{MONTH}}-{{DAY}}-{{HOUR}}-{{MINUTE}}/{{UUID}}.parquet"
-    format: "parquet"
-    athena: true # <- set this to true for Athena compatibility
+    path: "cloudquery/{{TABLE}}/{{YEAR}}-{{MONTH}}-{{DAY}}-{{HOUR}}-{{MINUTE}}/{{UUID}}.parquet"
+    format: "json"

--- a/images/cloud_asset_inventory/cloudquery/find_denied_permissions.sh
+++ b/images/cloud_asset_inventory/cloudquery/find_denied_permissions.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Script to find all AWS permissions that were denied in a log file
-
-# Usage: ./find_denied_permissions.sh <log_file>
-# Output: denied_permissions.txt
-
-# Permissions denied appear after the string pattern "not authorized to perform:" in the log file
-grep "not authorized to perform:" "$1" | grep -E -io "([A-z0-9]+:[A-z]+) " | sort | uniq > denied_permissions.txt


### PR DESCRIPTION
# Summary | Résumé

Changing the S3 file format to JSON so that the sentinel_forwarder module can be leveraged.