### PR TITLE
fix: remove hour and minute from path

### DIFF
--- a/images/cloud_asset_inventory/cloudquery/config.yml
+++ b/images/cloud_asset_inventory/cloudquery/config.yml
@@ -42,5 +42,5 @@ spec:
   spec:
     bucket: ${CQ_S3_BUCKET}
     region: "ca-central-1"
-    path: "cloudquery/{{TABLE}}/{{YEAR}}-{{MONTH}}-{{DAY}}-{{HOUR}}-{{MINUTE}}/{{UUID}}.json"
+    path: "cloudquery/{{TABLE}}/{{YEAR}}-{{MONTH}}-{{DAY}}/{{UUID}}.json"
     format: "json"


### PR DESCRIPTION
# Summary | Résumé

Remove Hour and Minutes from S3 object path for simplicity and reduced number of folders 

More specifically, some tables logs get saved in multiple objects across different folders for the same daily run since it lasts longer than a single minute to parse all the cloud assets.

The actual run time is saved in each log so it doesn't have to be in the path.