### PR TITLE
Feat/upgrade CloudQuery to 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ This repository will contain various tools used by CDS to ensure the confidentia
 ## License
 
 This code is released under the MIT License. See [LICENSE](LICENSE).
+
+## Maintenance
+
+### Upgrading CloudQuery
+
+1. Update the `cloudquery` image tag in `Dockerfile` to the latest version (path: /workspace/images/cloud_asset_inventory/cloudquery/Dockerfile)
+2. In VS Code, run the devcontainer to build the new image and start the container
+3. Assume the PlatformSecurity role in the AWS account you want to scan and export the credentials to your environment
+4. Export the CQ_S3_BUCKET variable to your environment with the name cloudquery-794722365809-test as the value (ex: `export CQ_S3_BUCKET=cloudquery-794722365809-test`)
+4. Run `make build-cq` to build the CloudQuery binary
+5. Run `make run-cloud-query` to run the CloudQuery container
+

--- a/images/cloud_asset_inventory/cloudquery/Dockerfile
+++ b/images/cloud_asset_inventory/cloudquery/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cloudquery/cloudquery:3.0@sha256:0e344a64d2af0b287471b8f7901e805d0b28abb6128e871d01ade30b9f8d63ac
+FROM ghcr.io/cloudquery/cloudquery:3.2@sha256:b6ad40516396ac81ef374186574decb45fae2454461705a31dcfb89818c3c1e0
 
 COPY config.yml /app
 

--- a/images/cloud_asset_inventory/cloudquery/config.yml
+++ b/images/cloud_asset_inventory/cloudquery/config.yml
@@ -2,7 +2,7 @@ kind: source
 spec:
   name: aws
   path: cloudquery/aws
-  version: "v15.4.0"
+  version: "v17.2.0"
   tables: ["*"]
   skip_tables:
   - aws_ec2_vpc_endpoint_services # this resource includes services that are available from AWS as well as other AWS Accounts


### PR DESCRIPTION
# Summary | Résumé

Upgrade:
- CQ version to 3.2
- AWS Source plugin to 17.2

Fixes https://github.com/cds-snc/security-tools/pull/278