### PR TITLE
fix: remove cloud asset inventory dependency

### DIFF
--- a/terragrunt/env/sso_proxy/terragrunt.hcl
+++ b/terragrunt/env/sso_proxy/terragrunt.hcl
@@ -10,15 +10,6 @@ dependency "base" {
   config_path = "../base"
 }
 
-dependency "cloud_asset_inventory" {
-  config_path = "../cloud_asset_inventory"
-
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
-  mock_outputs = {
-    cloud_asset_inventory_load_balancer_dns = "my-loadbalancer-1234567890.ca-central-1.elb.amazonaws.com"
-  }
-}
-
 dependency "csp_violation_report_service" {
   config_path = "../csp_violation_report_service"
 
@@ -42,7 +33,6 @@ inputs = {
   vpc_private_subnet_ids    = dependency.base.outputs.vpc_private_subnet_ids
   vpc_public_subnet_ids     = dependency.base.outputs.vpc_public_subnet_ids
 
-  cloud_asset_inventory_load_balancer_dns        = dependency.cloud_asset_inventory.outputs.cloud_asset_inventory_load_balancer_dns
   csp_violation_report_service_load_balancer_dns = dependency.csp_violation_report_service.outputs.csp_violation_report_service_load_balancer_dns
 }
 


### PR DESCRIPTION
# Summary
The SSO proxy no longer has a Terragrunt dependency on the cloud asset inventory.