### PR TITLE
Feat/upgrade cq config

### DIFF
--- a/images/cloud_asset_inventory/cloudquery/Dockerfile
+++ b/images/cloud_asset_inventory/cloudquery/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cloudquery/cloudquery:3.2@sha256:19b437fdb5a65b79c8e085e3de9ba8e5dc9349018977b543c8062b01e364f5e1
+FROM ghcr.io/cloudquery/cloudquery:3.5@sha256:37a3b6e2c0aa1fe64b5b84bf0a252ff704e52d2835074bc2941c11f7f0be5d75
 
 COPY config.yml /app
 

--- a/images/cloud_asset_inventory/cloudquery/config.yml
+++ b/images/cloud_asset_inventory/cloudquery/config.yml
@@ -2,7 +2,7 @@ kind: source
 spec:
   name: aws
   path: cloudquery/aws
-  version: "v17.2.0"
+  version: "v17.4.0"
   tables: ["*"]
   skip_tables:
   - aws_ec2_vpc_endpoint_services # this resource includes services that are available from AWS as well as other AWS Accounts
@@ -25,6 +25,7 @@ spec:
   - aws_rds_engine_versions
   - aws_servicequotas_services
   destinations: ["s3"]
+  concurrency: 2000
   spec:
     regions:
       - ca-central-1
@@ -37,7 +38,7 @@ kind: destination
 spec:
   name: "s3"
   path: "cloudquery/s3"
-  version: "v3.1.0"
+  version: "v4.4.0"
   write_mode: "append" # s3 only supports 'append' mode
   spec:
     bucket: ${CQ_S3_BUCKET}


### PR DESCRIPTION
# Summary | Résumé

- Upgrading CQ to 3.5 and plugins to latest versions
- Setting concurrency to 2000 to reduce number of times we hit the API rate limits.