### PR TITLE
fix: revert to oidc v2.0.1

### DIFF
--- a/terragrunt/aws/base/oidc.tf
+++ b/terragrunt/aws/base/oidc.tf
@@ -5,7 +5,7 @@ locals {
 
 
 module "oidc" {
-  source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v6.1.1"
+  source            = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v2.0.1"
   billing_tag_key   = var.billing_tag_key
   billing_tag_value = var.billing_tag_value
   oidc_exists       = true


### PR DESCRIPTION
# Summary | Résumé

Reverting to gh_oidc_role v2.0.1 (last known working config)