### PR TITLE
Changing the terraform module reference links

### DIFF
--- a/terragrunt/aws/base/s3.tf
+++ b/terragrunt/aws/base/s3.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "log_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.47//S3_log_bucket"
+  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v7.0.0"
   bucket_name       = "${local.name_prefix}-logs"
   billing_tag_value = var.billing_tag_value
 }


### PR DESCRIPTION
# Summary | Résumé

Updating the terraform module references according to the terraform documentation - https://developer.hashicorp.com/terraform/language/modules/sources#modules-in-package-sub-directories.