### PR TITLE
feat: CloudFront distribution to front Lambda URL

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,6 +1,9 @@
 skip-check:
   - CKV_AWS_51  # ECR: mutable images is acceptable since the latest tag will be used
+  - CKV_AWS_68  # Cloudfront: deploying without WAF is acceptable risk
+  - CKV_AWS_86  # Cloudfront: deploying without logging is acceptable risk
   - CKV_AWS_158 # CloudWatch: default AWS Managed encryption key is acceptable
   - CKV_AWS_184 # EFS: default AWS Managed encryption key is acceptable
   - CKV_AWS_231 # port 3389 blocked by the vpc terraform module using the block_rdp flag
   - CKV_AWS_241 # Kinesis firehose: default AWS Managed encryption key is acceptable
+  - CKV2_AWS_32 # Cloudfront: false-positive; a strict header security policy is attached

--- a/terragrunt/aws/csp_violation_report_service/certificate.tf
+++ b/terragrunt/aws/csp_violation_report_service/certificate.tf
@@ -1,0 +1,41 @@
+resource "aws_acm_certificate" "csp_reports" {
+  provider = aws.us-east-1
+
+  domain_name               = var.tool_domain_name
+  subject_alternative_names = ["*.${var.tool_domain_name}"]
+  validation_method         = "DNS"
+
+  tags = {
+    CostCentre = var.tool_name
+    Terraform  = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "csp_reports_cert_validation" {
+  zone_id = var.hosted_zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.csp_reports.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "csp_reports" {
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.csp_reports.arn
+  validation_record_fqdns = [for record in aws_route53_record.csp_reports_cert_validation : record.fqdn]
+}

--- a/terragrunt/aws/csp_violation_report_service/cloudfront.tf
+++ b/terragrunt/aws/csp_violation_report_service/cloudfront.tf
@@ -20,14 +20,14 @@ resource "aws_cloudfront_distribution" "csp_reports" {
     allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods  = ["GET", "HEAD"]
 
-    target_origin_id           = aws_lambda_function_url.csp_reports.function_name
-    viewer_protocol_policy     = "redirect-to-https"
+    target_origin_id       = aws_lambda_function_url.csp_reports.function_name
+    viewer_protocol_policy = "redirect-to-https"
 
     response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03" # SecurityHeadersPolicy https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html
     cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
     origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
 
-    compress    = true
+    compress = true
   }
 
   restrictions {

--- a/terragrunt/aws/csp_violation_report_service/cloudfront.tf
+++ b/terragrunt/aws/csp_violation_report_service/cloudfront.tf
@@ -1,0 +1,49 @@
+resource "aws_cloudfront_distribution" "csp_reports" {
+  enabled     = true
+  aliases     = [var.tool_domain_name]
+  price_class = "PriceClass_100"
+
+  origin {
+    domain_name = split("/", aws_lambda_function_url.csp_reports.function_url)[2]
+    origin_id   = aws_lambda_function_url.csp_reports.function_name
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_read_timeout    = 60
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods  = ["GET", "HEAD"]
+
+    target_origin_id           = aws_lambda_function_url.csp_reports.function_name
+    viewer_protocol_policy     = "redirect-to-https"
+
+    response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03" # SecurityHeadersPolicy https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # CachingDisabled https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+    origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+
+    compress    = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.csp_reports.certificate_arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
+  }
+
+  tags = {
+    CostCentre = var.tool_name
+    Terraform  = true
+  }
+}

--- a/terragrunt/aws/csp_violation_report_service/inputs.tf
+++ b/terragrunt/aws/csp_violation_report_service/inputs.tf
@@ -1,3 +1,8 @@
+variable "hosted_zone_id" {
+  description = "The hosted zone ID to create DNS records in"
+  type        = string
+}
+
 variable "log_analytics_workspace_id" {
   description = "The Sentinel workspace ID. Used by the Sentinel Forwarder to send the CSP reports to Sentinel."
   type        = string
@@ -8,4 +13,9 @@ variable "log_analytics_workspace_key" {
   description = "The Sentinel workspace authentication key. Used by the Sentinel Forwarder to send the CSP reports to Sentinel."
   type        = string
   sensitive   = true
+}
+
+variable "tool_domain_name" {
+  description = "The domain name to use for the tool"
+  type        = string
 }

--- a/terragrunt/aws/csp_violation_report_service/lambda.tf
+++ b/terragrunt/aws/csp_violation_report_service/lambda.tf
@@ -4,9 +4,10 @@ module "csp_reports" {
   ecr_arn   = aws_ecr_repository.csp_reports.arn
   image_uri = "${aws_ecr_repository.csp_reports.repository_url}:latest"
 
-  memory                 = 1024
-  timeout                = 120
-  enable_lambda_insights = true
+  memory                         = 256
+  timeout                        = 15
+  enable_lambda_insights         = true
+  reserved_concurrent_executions = 10
 
   billing_tag_value = var.tool_name
 }

--- a/terragrunt/aws/csp_violation_report_service/route53.tf
+++ b/terragrunt/aws/csp_violation_report_service/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "csp_reports_A" {
+  zone_id = var.hosted_zone_id
+  name    = var.tool_domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.csp_reports.domain_name
+    zone_id                = aws_cloudfront_distribution.csp_reports.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -11,3 +11,8 @@ terraform {
 provider "aws" {
   region = var.region
 }
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}

--- a/terragrunt/env/csp_violation_report_service/.terraform.lock.hcl
+++ b/terragrunt/env/csp_violation_report_service/.terraform.lock.hcl
@@ -1,9 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.4.0"
+  hashes = [
+    "h1:EtN1lnoHoov3rASpgGmh6zZ/W6aRCTgKC7iMwvFY1yc=",
+    "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
+    "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
+    "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
+    "zh:70dae36c176aa2b258331ad366a471176417a94dd3b4985a911b8be9ff842b00",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d8c8e3925f1e21daf73f85983894fbe8868e326910e6df3720265bc657b9c9c",
+    "zh:a032ec0f0aee27a789726e348e8ad20778c3a1c9190ef25e7cff602c8d175f44",
+    "zh:b8e50de62ba185745b0fe9713755079ad0e9f7ac8638d204de6762cc36870410",
+    "zh:c8ad0c7697a3d444df21ff97f3473a8604c8639be64afe3f31b8ec7ad7571e18",
+    "zh:df736c5a2a7c3a82c5493665f659437a22f0baf8c2d157e45f4dd7ca40e739fc",
+    "zh:e8ffbf578a0977074f6d08aa8734e36c726e53dc79894cfc4f25fadc4f45f1df",
+    "zh:efea57ff23b141551f92b2699024d356c7ffd1a4ad62931da7ed7a386aef7f1f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
-  constraints = "~> 4.49"
+  constraints = ">= 3.46.0, ~> 4.49"
   hashes = [
     "h1:3t9uBosa4EwbJF7f8LONm4YO3vB9r5CFSgxKiP3UrYw=",
     "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
@@ -34,52 +53,5 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
     "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
     "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/random" {
-  version = "3.5.1"
-  hashes = [
-    "h1:0ULxM8/DscMzfiDWg1yclBf/39U44wQmlx745BfYZ80=",
-    "h1:3hjTP5tQBspPcFAJlfafnWrNrKnr7J4Cp0qB9jbqf30=",
-    "h1:6FVyQ/aG6tawPam6B+oFjgdidKd83uG9n7dOSQ66HBA=",
-    "h1:6ePAACdONiMGe1j5pwUc0gpDFt82y/ka0zRimMg/geM=",
-    "h1:BD3Y4CcrGHb9sx+Bl5V8M2PSyw23mykzXSwj+/6FhHA=",
-    "h1:HGeb7Tajn7HZwX0MhrdyL57LoCSz5GMcI2wbHs12D4U=",
-    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
-    "h1:JiENkIxSWc32/2Dtd1n4CWY3ow/PHvAeGhdgcOLpWZM=",
-    "h1:MROYZuKGTuaTNf2FgbwCgSVpteQW25ubnb+Xfok2jvk=",
-    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
-    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
-    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
-    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
-    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
-    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
-    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
-    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
-    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
-    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
-    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
-    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
   ]
 }

--- a/terragrunt/env/csp_violation_report_service/terragrunt.hcl
+++ b/terragrunt/env/csp_violation_report_service/terragrunt.hcl
@@ -8,10 +8,17 @@ dependencies {
 
 dependency "base" {
   config_path = "../base"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    hosted_zone_id = "1234567890"
+  }  
 }
 
 inputs = {
-  tool_name = "csp_violation_report_service"
+  hosted_zone_id   = dependency.base.outputs.hosted_zone_id
+  tool_name        = "csp_violation_report_service"
+  tool_domain_name = "csp-report-to.${local.vars.inputs.domain_name}"
 }
 
 include {

--- a/terragrunt/env/csp_violation_report_service/terragrunt.hcl
+++ b/terragrunt/env/csp_violation_report_service/terragrunt.hcl
@@ -1,3 +1,7 @@
+locals {
+  parent_vars = read_terragrunt_config("../terragrunt.hcl")
+}
+
 terraform {
   source = "../../aws//csp_violation_report_service"
 }
@@ -18,7 +22,7 @@ dependency "base" {
 inputs = {
   hosted_zone_id   = dependency.base.outputs.hosted_zone_id
   tool_name        = "csp_violation_report_service"
-  tool_domain_name = "csp-report-to.${local.vars.inputs.domain_name}"
+  tool_domain_name = "csp-report-to.${local.parent_vars.inputs.domain_name}"
 }
 
 include {


### PR DESCRIPTION
# Summary
Add CloudFront distribution to provide a custom URL for the CSP report service's Lambda function URL.

# Related
- https://github.com/cds-snc/platform-core-services/issues/393