### PR TITLE
feat: CloudFront WAF and CloudWatch alarms

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,6 +1,5 @@
 skip-check:
   - CKV_AWS_51  # ECR: mutable images is acceptable since the latest tag will be used
-  - CKV_AWS_68  # Cloudfront: deploying without WAF is acceptable risk
   - CKV_AWS_86  # Cloudfront: deploying without logging is acceptable risk
   - CKV_AWS_158 # CloudWatch: default AWS Managed encryption key is acceptable
   - CKV_AWS_184 # EFS: default AWS Managed encryption key is acceptable

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -3,6 +3,8 @@ skip-check:
   - CKV_AWS_86  # Cloudfront: deploying without logging is acceptable risk
   - CKV_AWS_158 # CloudWatch: default AWS Managed encryption key is acceptable
   - CKV_AWS_184 # EFS: default AWS Managed encryption key is acceptable
+  - CKV_AWS_192 # WAF: Log4j is not used
   - CKV_AWS_231 # port 3389 blocked by the vpc terraform module using the block_rdp flag
   - CKV_AWS_241 # Kinesis firehose: default AWS Managed encryption key is acceptable
+  - CKV2_AWS_31 # WAF: logging is not required
   - CKV2_AWS_32 # Cloudfront: false-positive; a strict header security policy is attached

--- a/terragrunt/aws/csp_violation_report_service/alarms.tf
+++ b/terragrunt/aws/csp_violation_report_service/alarms.tf
@@ -1,0 +1,28 @@
+resource "aws_cloudwatch_log_metric_filter" "csp_report_error" {
+  name           = "CSPReportError"
+  pattern        = "?ERROR ?Error"
+  log_group_name = local.csp_reports_log_group_name
+
+  metric_transformation {
+    name      = "CSPReportError"
+    namespace = "CSPReportError"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "csp_report_error" {
+  alarm_name          = "CSP Report Error"
+  alarm_description   = "Error logged by the service's lambda function"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.csp_report_error.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.csp_report_error.metric_transformation[0].namespace
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = 1
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [local.sns_alarm_topic_arn]
+  ok_actions    = [local.sns_alarm_topic_arn]
+}

--- a/terragrunt/aws/csp_violation_report_service/cloudfront.tf
+++ b/terragrunt/aws/csp_violation_report_service/cloudfront.tf
@@ -2,6 +2,7 @@ resource "aws_cloudfront_distribution" "csp_reports" {
   enabled     = true
   aliases     = [var.tool_domain_name]
   price_class = "PriceClass_100"
+  web_acl_id  = aws_wafv2_web_acl.csp_report.arn
 
   origin {
     domain_name = split("/", aws_lambda_function_url.csp_reports.function_url)[2]

--- a/terragrunt/aws/csp_violation_report_service/locals.tf
+++ b/terragrunt/aws/csp_violation_report_service/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  csp_reports_log_group_name = "/aws/lambda/${module.csp_reports.function_name}"
+  csp_reports_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.csp_reports_log_group_name}"
+  sns_alarm_topic_arn        = "arn:aws:sns:${var.region}:${var.account_id}:internal-sre-alert"
+}

--- a/terragrunt/aws/csp_violation_report_service/sentinel.tf
+++ b/terragrunt/aws/csp_violation_report_service/sentinel.tf
@@ -1,8 +1,3 @@
-locals {
-  csp_reports_log_group_name = "/aws/lambda/${module.csp_reports.function_name}"
-  csp_reports_log_group_arn  = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.csp_reports_log_group_name}"
-}
-
 module "sentinel_forwarder" {
   source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v7.0.1"
   function_name     = "${var.tool_name}_sentinel"

--- a/terragrunt/aws/csp_violation_report_service/waf.tf
+++ b/terragrunt/aws/csp_violation_report_service/waf.tf
@@ -1,0 +1,160 @@
+resource "aws_wafv2_web_acl" "csp_report" {
+  provider = aws.us-east-1
+
+  name        = "csp_report"
+  description = "WAF for CSP report service"
+  scope       = "CLOUDFRONT"
+
+  tags = {
+    CostCentre = var.billing_tag_value
+    Terraform  = true
+  }
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "InvalidRequest"
+    priority = 10
+
+    action {
+      block {}
+    }
+
+    statement {
+      not_statement {
+        statement {
+          and_statement {
+            statement {
+              byte_match_statement {
+                search_string = "post"
+                field_to_match {
+                  method {}
+                }
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+            statement {
+              regex_pattern_set_reference_statement {
+                arn = aws_wafv2_regex_pattern_set.valid_uri_paths.arn
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 1
+                  type     = "COMPRESS_WHITE_SPACE"
+                }
+                text_transformation {
+                  priority = 2
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "InvalidPaths"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimit"
+    priority = 20
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 500
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 30
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 40
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "csp_report"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
+  provider    = aws.us-east-1
+  name        = "ValidURIPaths"
+  description = "Regex to match the CSP report valid URI paths"
+  scope       = "CLOUDFRONT"
+
+  regular_expression {
+    regex_string = "^/report$"
+  }
+
+  tags = {
+    CostCentre = var.billing_tag_value
+    Terraform  = true
+  }
+}

--- a/terragrunt/aws/csp_violation_report_service/waf.tf
+++ b/terragrunt/aws/csp_violation_report_service/waf.tf
@@ -28,7 +28,8 @@ resource "aws_wafv2_web_acl" "csp_report" {
           and_statement {
             statement {
               byte_match_statement {
-                search_string = "post"
+                search_string         = "post"
+                positional_constraint = "EXACTLY"
                 field_to_match {
                   method {}
                 }
@@ -43,8 +44,9 @@ resource "aws_wafv2_web_acl" "csp_report" {
               }
             }
             statement {
-              regex_pattern_set_reference_statement {
-                arn = aws_wafv2_regex_pattern_set.valid_uri_paths.arn
+              byte_match_statement {
+                search_string         = "/report"
+                positional_constraint = "EXACTLY"
                 field_to_match {
                   uri_path {}
                 }
@@ -140,21 +142,5 @@ resource "aws_wafv2_web_acl" "csp_report" {
     cloudwatch_metrics_enabled = true
     metric_name                = "csp_report"
     sampled_requests_enabled   = false
-  }
-}
-
-resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
-  provider    = aws.us-east-1
-  name        = "ValidURIPaths"
-  description = "Regex to match the CSP report valid URI paths"
-  scope       = "CLOUDFRONT"
-
-  regular_expression {
-    regex_string = "^/report$"
-  }
-
-  tags = {
-    CostCentre = var.billing_tag_value
-    Terraform  = true
   }
 }


### PR DESCRIPTION
# Summary
Add a WAF for the CSP report service's CloudFront distribution.

Add CloudWatch alarms for errors from the CSP
report service.

# Related
- https://github.com/cds-snc/security-tools/issues/102