### PR TITLE
fix: update CSP error alarm to catch Exceptions only

### DIFF
--- a/terragrunt/aws/csp_violation_report_service/alarms.tf
+++ b/terragrunt/aws/csp_violation_report_service/alarms.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "csp_report_error" {
   name           = "CSPReportError"
-  pattern        = "?ERROR ?Error"
+  pattern        = "?ERROR ?Traceback"
   log_group_name = local.csp_reports_log_group_name
 
   metric_transformation {

--- a/terragrunt/aws/csp_violation_report_service/lambda.tf
+++ b/terragrunt/aws/csp_violation_report_service/lambda.tf
@@ -1,5 +1,5 @@
 module "csp_reports" {
-  source    = "github.com/cds-snc/terraform-modules//lambda?ref=v8.0.0"
+  source    = "github.com/cds-snc/terraform-modules//lambda?ref=v9.2.1"
   name      = var.tool_name
   ecr_arn   = aws_ecr_repository.csp_reports.arn
   image_uri = "${aws_ecr_repository.csp_reports.repository_url}:latest"


### PR DESCRIPTION
# Summary
Update the CSP CloudWatch `error` metric alarm to catch exceptions rather than CSP violations that include the word `Error`.