### PR TITLE
chore: update to latest Sentinel Forwarder module

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/sentinel_forwarder.tf
+++ b/terragrunt/aws/cloud_asset_inventory/sentinel_forwarder.tf
@@ -1,5 +1,5 @@
 module "sentinel_forwarder" {
-  source = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v8.0.0"
+  source = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.3.8"
 
   function_name = "cloudquery-sentinel-forwarder"
   customer_id   = var.customer_id
@@ -7,7 +7,7 @@ module "sentinel_forwarder" {
 
   log_type = local.cloudquery_service_name
 
-  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:56"
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:125"
 
   s3_sources = [
     {

--- a/terragrunt/aws/csp_violation_report_service/sentinel.tf
+++ b/terragrunt/aws/csp_violation_report_service/sentinel.tf
@@ -1,9 +1,9 @@
 module "sentinel_forwarder" {
-  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v8.0.0"
+  source            = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v9.3.8"
   function_name     = "${var.tool_name}_sentinel"
   billing_tag_value = var.tool_name
 
-  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:87"
+  layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:125"
 
   customer_id = var.log_analytics_workspace_id
   shared_key  = var.log_analytics_workspace_key


### PR DESCRIPTION
# Summary
Update to the Terraform Sentinel Forwarder module that does not store its authentication credentials as Lambda env vars.

# Related
- https://github.com/cds-snc/platform-core-services/issues/557
- https://github.com/cds-snc/site-reliability-engineering/issues/1215