### PR TITLE
fix: remove SHA pins on devcontainer features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,14 +13,14 @@
       "version": "latest",
       "moby": true
     },
-    "ghcr.io/devcontainers/features/aws-cli:1@sha256:8d39e89cc98291953fb03cf7ef540dc1a7c78c3162f0eee9b61c800e4838f807": {},
-    "ghcr.io/devcontainers/features/github-cli:1@sha256:464564228ccdd6028f01f8a62a3cfbaf76e9ba7953b29ac0e53ba2c262604312": {},
-    "ghcr.io/devcontainers/features/terraform:1@sha256:403fe3406aaf4618d9ca5b79cd1bd4a3576eac8816b18419650ab2f87026bb09": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/terraform:1": {
       "version": "1.1.9",
       "tflint": "latest",
       "terragrunt": "0.36.7"
     },
-    "ghcr.io/devcontainers/features/python:1@sha256:bf021f1800543f08bf029c449a3f25341be782b620802befa1f8e6ee51cf6cf6": {}
+    "ghcr.io/devcontainers/features/python:1": {}
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
# Summary
Remove the broken dependency pins on the devcontainer features.  These were accidentally added by a Renovate PR.