### PR TITLE
feat: add ECR for generate SBOM action

### DIFF
--- a/.github/workflows/generate-sbom-terragrunt-apply.yml
+++ b/.github/workflows/generate-sbom-terragrunt-apply.yml
@@ -1,0 +1,56 @@
+name: "Terragrunt apply generate SBOM"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/generate-sbom-terragrunt-apply.yml"
+      - "terragrunt/*/generate_sbom/**"
+      - "terragrunt/*/common/**"
+      - "terragrunt/env/terragrunt.hcl"
+
+env:
+  AWS_REGION: ca-central-1
+  CONFTEST_VERSION: 0.27.0
+  TERRAFORM_VERSION: 1.1.9
+  TERRAGRUNT_VERSION: 0.36.7
+  TF_INPUT: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terragrunt-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - uses: cds-snc/paths-filter@b316143212d841aed668b7b29240c719d603a9b9 # v2.10.4
+        id: filter
+        with:
+          filters: |
+            generate_sbom:
+              - 'terragrunt/aws/generate_sbom/**'
+              - 'terragrunt/env/generate_sbom/**'
+            common:
+              - '.github/workflows/generate-sbom-terragrunt-apply.yml'
+              - 'terragrunt/env/common/**'
+              - 'terragrunt/env/terragrunt.hcl'
+
+      - name: configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/security-tools-apply
+          role-session-name: TFApply
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terragrunt apply generate SBOM
+        if: ${{ steps.filter.outputs.generate_sbom == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: "terragrunt/env/generate_sbom"
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/generate-sbom-terragrunt-plan.yml
+++ b/.github/workflows/generate-sbom-terragrunt-plan.yml
@@ -1,0 +1,61 @@
+name: "Terragrunt plan generate SBOM"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/generate-sbom-terragrunt-plan.yml"
+      - "terragrunt/*/generate_sbom/**"
+      - "terragrunt/*/common/**"
+      - "terragrunt/env/terragrunt.hcl"
+
+env:
+  AWS_REGION: ca-central-1
+  CONFTEST_VERSION: 0.27.0
+  TERRAFORM_VERSION: 1.1.9
+  TERRAGRUNT_VERSION: 0.36.7
+  TF_INPUT: false
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  terragrunt-plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - uses: cds-snc/paths-filter@b316143212d841aed668b7b29240c719d603a9b9 # v2.10.4
+        id: filter
+        with:
+          filters: |
+            generate_sbom:
+              - 'terragrunt/aws/generate_sbom/**'
+              - 'terragrunt/env/generate_sbom/**'
+            common:
+              - '.github/workflows/generate-sbom-terragrunt-plan.yml'
+              - 'terragrunt/env/common/**'
+              - 'terragrunt/env/terragrunt.hcl'
+
+      - name: configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/security-tools-plan
+          role-session-name: TFPlan
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terragrunt plan generate SBOM
+        if: ${{ steps.filter.outputs.generate_sbom == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@4719878d72d1b0078e0bce2e7571e854e79903b8 # v3.2.2
+        with:
+          directory: "terragrunt/env/generate_sbom"
+          comment-delete: "true"
+          comment-title: "generate_sbom"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@ connector.zip
 __pycache__/
 *.py[cod]
 *$py.class
-
-**/env/*

--- a/terragrunt/aws/generate_sbom/ecr.tf
+++ b/terragrunt/aws/generate_sbom/ecr.tf
@@ -6,6 +6,10 @@ resource "aws_ecr_repository" "generate_sbom" {
     scan_on_push = true
   }
 
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true

--- a/terragrunt/aws/generate_sbom/ecr.tf
+++ b/terragrunt/aws/generate_sbom/ecr.tf
@@ -1,0 +1,14 @@
+resource "aws_ecr_repository" "generate_sbom" {
+  name                 = "${var.product_name}/generate_sbom/trivy"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = "${var.product_name}-${var.tool_name}"
+  }
+}

--- a/terragrunt/env/generate_sbom/terragrunt.hcl
+++ b/terragrunt/env/generate_sbom/terragrunt.hcl
@@ -1,0 +1,16 @@
+locals {
+  parent_vars = read_terragrunt_config("../terragrunt.hcl")
+}
+
+terraform {
+  source = "../../aws//generate_sbom"
+}
+
+inputs = {
+  tool_name = "generate_sbom"
+}
+
+include {
+  path   = find_in_parent_folders()
+  expose = true
+}


### PR DESCRIPTION
# Summary
Add an ECR that will be used to hold the Docker images needed by trivy for the `generate-sbom` GitHub action.

This ECR will be used to host our own copy of the trivy database to address the `TOOMANYREQUESTS` throttling errors we've been getting from the public Docker repository.

# Related
- https://github.com/cds-snc/platform-core-services/issues/597