### PR TITLE
Create a public ECR for Sbom scans

### DIFF
--- a/.github/workflows/generate-sbom-terragrunt-apply.yml
+++ b/.github/workflows/generate-sbom-terragrunt-apply.yml
@@ -15,6 +15,7 @@ env:
   CONFTEST_VERSION: 0.27.0
   TERRAFORM_VERSION: 1.1.9
   TERRAGRUNT_VERSION: 0.36.7
+  TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_INPUT: false
 
 permissions:

--- a/.github/workflows/generate-sbom-terragrunt-plan.yml
+++ b/.github/workflows/generate-sbom-terragrunt-plan.yml
@@ -14,6 +14,7 @@ env:
   CONFTEST_VERSION: 0.27.0
   TERRAFORM_VERSION: 1.1.9
   TERRAGRUNT_VERSION: 0.36.7
+  TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_INPUT: false
 
 permissions:

--- a/terragrunt/aws/generate_sbom/ecr.tf
+++ b/terragrunt/aws/generate_sbom/ecr.tf
@@ -1,22 +1,3 @@
-resource "aws_ecr_repository" "generate_sbom" {
-  name                 = "${var.product_name}/generate_sbom/trivy"
-  image_tag_mutability = "MUTABLE"
-
-  image_scanning_configuration {
-    scan_on_push = true
-  }
-
-  encryption_configuration {
-    encryption_type = "KMS"
-  }
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = true
-    Product               = "${var.product_name}-${var.tool_name}"
-  }
-}
-
 resource "aws_ecrpublic_repository" "generate_sbom_public" {
   provider        = aws.us-east-1
   repository_name = "${var.product_name}/generate_sbom/trivy"

--- a/terragrunt/aws/generate_sbom/ecr.tf
+++ b/terragrunt/aws/generate_sbom/ecr.tf
@@ -16,3 +16,40 @@ resource "aws_ecr_repository" "generate_sbom" {
     Product               = "${var.product_name}-${var.tool_name}"
   }
 }
+
+resource "aws_ecrpublic_repository" "generate_sbom_public" {
+  provider        = aws.us-east-1
+  repository_name = "${var.product_name}/generate_sbom_public/trivy"
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+    Product               = "${var.product_name}-${var.tool_name}"
+  }
+}
+data "aws_iam_policy_document" "sbom_public_policy_document" {
+  provider = aws.us-east-1
+  statement {
+    sid    = "sbom_public_policy"
+    effect = "Allow"
+
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [var.aws_org_id]
+    }
+  }
+}
+resource "aws_ecrpublic_repository_policy" "sbom_public_policy" {
+  provider        = aws.us-east-1
+  repository_name = aws_ecrpublic_repository.generate_sbom_public.repository_name
+  policy          = data.aws_iam_policy_document.sbom_public_policy_document.json
+}

--- a/terragrunt/aws/generate_sbom/ecr.tf
+++ b/terragrunt/aws/generate_sbom/ecr.tf
@@ -19,7 +19,7 @@ resource "aws_ecr_repository" "generate_sbom" {
 
 resource "aws_ecrpublic_repository" "generate_sbom_public" {
   provider        = aws.us-east-1
-  repository_name = "${var.product_name}/generate_sbom_public/trivy"
+  repository_name = "${var.product_name}/generate_sbom/trivy"
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
@@ -38,8 +38,19 @@ data "aws_iam_policy_document" "sbom_public_policy_document" {
       identifiers = ["*"]
     }
     actions = [
-      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchDeleteImage",
       "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:SetRepositoryPolicy",
+      "ecr:UploadLayerPart"
     ]
     condition {
       test     = "StringEquals"
@@ -51,5 +62,5 @@ data "aws_iam_policy_document" "sbom_public_policy_document" {
 resource "aws_ecrpublic_repository_policy" "sbom_public_policy" {
   provider        = aws.us-east-1
   repository_name = aws_ecrpublic_repository.generate_sbom_public.repository_name
-  policy          = data.aws_iam_policy_document.sbom_public_policy_document.json
+  policy          = sensitive(data.aws_iam_policy_document.sbom_public_policy_document.json)
 }

--- a/terragrunt/aws/generate_sbom/inputs.tf
+++ b/terragrunt/aws/generate_sbom/inputs.tf
@@ -1,0 +1,5 @@
+variable "aws_org_id" {
+  description = "The AWS org account ID.  Used to limit which accounts can access the public repository."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# Summary | Résumé

Adding a public ECR repository for the SBOM scans. A couple of considerations:

1. An ECR public repository can only live in us-east-1 (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecrpublic_repository)
2. I did not delete the original private ECR since I was not sure if you wanted to have it up regardless.
3. I was not sure where this is being used so did not change any references to the public repository. 
