### PR TITLE
fix: update generate SBOM repo name

### DIFF
--- a/terragrunt/aws/generate_sbom/ecr.tf
+++ b/terragrunt/aws/generate_sbom/ecr.tf
@@ -1,6 +1,6 @@
 resource "aws_ecrpublic_repository" "generate_sbom_public" {
   provider        = aws.us-east-1
-  repository_name = "${var.product_name}/generate_sbom/trivy"
+  repository_name = "${var.product_name}/generate_sbom/trivy-db"
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true


### PR DESCRIPTION
# Summary
Update the public repository name as this will contain the Trivy database.

# Related
- https://github.com/cds-snc/platform-core-services/issues/597