### PR TITLE
chore: upgrade to latest version of Trivy

### DIFF
--- a/.github/actions/docker-scan/action.yml
+++ b/.github/actions/docker-scan/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Run docker vulnerability scanner
-      uses: aquasecurity/trivy-action@207cd40078971bb7a078f8504c2061f908569449
+      uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
       with:
         image-ref: "${{ inputs.docker_image }}"
         format: "sarif"

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Install Trivy
       env:
-        TRIVY_VERSION: "v0.36.0"
+        TRIVY_VERSION: "v0.56.1"
       run: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | \
           sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}


### PR DESCRIPTION
# Summary
Upgrade the Docker vulnerability scan and generate SBOM actions to use the latest version of Trivy.

# Related
- https://github.com/cds-snc/platform-core-services/issues/597