### PR TITLE
feat: add nightly job to refresh Trivy database

### DIFF
--- a/.github/workflows/trivy-db-refresh.yml
+++ b/.github/workflows/trivy-db-refresh.yml
@@ -1,0 +1,38 @@
+name: Trivy Database Refresh
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 3 * * *" # Attempting to run at an off-peak time
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  docker-vulnerability-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/security-tools-apply
+          role-session-name: ECRPush
+          aws-region: us-east-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registry-type: public
+
+      - name: Refresh Trivy Database
+        run: |
+          ./bin/generate_sbom/trivy_db_refresh.sh ${{ vars.TRIVY_DB_REPOSITORY }}
+
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/bin/generate_sbom/trivy_db_refresh.sh
+++ b/bin/generate_sbom/trivy_db_refresh.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# Attempts to refresh the Trivy Database in the specified target repository.
+# Uses backoff strategy to retry on failure since there have been intermittent rate
+# limiting issues with the source ECR public registry.
+#
+# This script expects that ECR authentication has already been performed.
+#
+
+target_repo="$1"
+max_attempts=5
+attempt=0
+backoff=1
+
+while [ $attempt -lt $max_attempts ]; do
+if oras cp public.ecr.aws/aquasecurity/trivy-db:latest "$target_repo"; then
+    echo "Trivy Database refreshed successfully."
+    break
+else
+    attempt=$((attempt + 1))
+    echo "Attempt $attempt failed. Retrying in $backoff seconds..."
+    sleep $backoff
+    backoff=$((backoff * 2))
+fi
+done
+
+if [ $attempt -eq $max_attempts ]; then
+    echo "Failed to refresh Trivy Database after $max_attempts attempts."
+    exit 1
+fi

--- a/bin/generate_sbom/trivy_db_refresh.sh
+++ b/bin/generate_sbom/trivy_db_refresh.sh
@@ -14,15 +14,15 @@ attempt=0
 backoff=1
 
 while [ $attempt -lt $max_attempts ]; do
-if oras cp public.ecr.aws/aquasecurity/trivy-db:latest "$target_repo"; then
-    echo "Trivy Database refreshed successfully."
-    break
-else
-    attempt=$((attempt + 1))
-    echo "Attempt $attempt failed. Retrying in $backoff seconds..."
-    sleep $backoff
-    backoff=$((backoff * 2))
-fi
+    if oras cp public.ecr.aws/aquasecurity/trivy-db:latest "$target_repo"; then
+        echo "Trivy Database refreshed successfully."
+        break
+    else
+        attempt=$((attempt + 1))
+        echo "Attempt $attempt failed. Retrying in $backoff seconds..."
+        sleep $backoff
+        backoff=$((backoff * 2))
+    fi
 done
 
 if [ $attempt -eq $max_attempts ]; then


### PR DESCRIPTION
# Summary
Add a nightly workflow that fetches the latest Trivy database.  This is then used by the CDS repos performing Docker scans.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/597