### PR TITLE
fix: Trivy Java DB refresh

### DIFF
--- a/.github/workflows/trivy-db-refresh.yml
+++ b/.github/workflows/trivy-db-refresh.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  docker-vulnerability-scan:
+  trivy-db-refresh:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/trivy-db-refresh.yml
+++ b/.github/workflows/trivy-db-refresh.yml
@@ -30,9 +30,10 @@ jobs:
         with:
           registry-type: public
 
-      - name: Refresh Trivy Database
+      - name: Refresh Trivy Databases
         run: |
           ./bin/generate_sbom/trivy_db_refresh.sh trivy-db:latest ${{ vars.TRIVY_DB_REPOSITORY }}
+          ./bin/generate_sbom/trivy_db_refresh.sh trivy-java-db:1 ${{ vars.TRIVY_JAVA_DB_REPOSITORY }}
 
       - name: Logout of Amazon ECR
         run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
# Summary
Fixed the Trivy Java DB refresh which allows us to host our own copy of the database.