### PR TITLE
Updating vpc settings and vpc version  

### DIFF
--- a/terragrunt/aws/base/vpc.tf
+++ b/terragrunt/aws/base/vpc.tf
@@ -3,6 +3,7 @@ module "vpc" {
   name   = "${var.product_name}-${var.tool_name}"
 
   availability_zones = 3
+  cidrsubnet_newbits = 8
   enable_flow_log    = false
   block_ssh          = true
   block_rdp          = true

--- a/terragrunt/aws/base/vpc.tf
+++ b/terragrunt/aws/base/vpc.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source = "github.com/cds-snc/terraform-modules//vpc?ref=v10.3.0"
   name   = "${var.product_name}-${var.tool_name}"
 
-  availability_zones = 3 
+  availability_zones = 3
   enable_flow_log    = false
   block_ssh          = true
   block_rdp          = true

--- a/terragrunt/aws/base/vpc.tf
+++ b/terragrunt/aws/base/vpc.tf
@@ -1,8 +1,8 @@
 module "vpc" {
-  source = "github.com/cds-snc/terraform-modules//vpc?ref=v8.0.0"
+  source = "github.com/cds-snc/terraform-modules//vpc?ref=v10.3.0"
   name   = "${var.product_name}-${var.tool_name}"
 
-  high_availability  = true
+  availability_zones = 3 
   enable_flow_log    = false
   block_ssh          = true
   block_rdp          = true


### PR DESCRIPTION
# Summary | Résumé

Removing the high_availability input and replacing it with the availability_zones variable instead as this was changed in the VPC module. Here is the commit that indicates this - https://github.com/cds-snc/terraform-modules/commit/7fc77cf456b17e320c871cc6418bd82a5cb2e28b

I am also updating the VPC module version since renovate is anyways trying to update it but failing due to the above - https://github.com/cds-snc/security-tools/pull/516

@patheard - I am just flagging you because it seems you worked last in this directory and because some resources will get recreated and I wanted to run it by you (just for sanity sake). 