### PR TITLE
fix: update function URL permissions

### DIFF
--- a/terragrunt/aws/csp_violation_report_service/lambda.tf
+++ b/terragrunt/aws/csp_violation_report_service/lambda.tf
@@ -16,3 +16,18 @@ resource "aws_lambda_function_url" "csp_reports" {
   function_name      = module.csp_reports.function_name
   authorization_type = "NONE"
 }
+
+resource "aws_lambda_permission" "csp_reports_invoke_function_url" {
+  statement_id           = "AllowInvokeFunctionUrl"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = module.csp_reports.function_name
+  function_url_auth_type = "NONE"
+  principal              = "*"
+}
+
+resource "aws_lambda_permission" "csp_reports_invoke_function" {
+  statement_id  = "AllowInvokeFunction"
+  action        = "lambda:InvokeFunction"
+  function_name = module.csp_reports.function_name
+  principal     = "*"
+}


### PR DESCRIPTION
# Summary
Update the Lambda function permissions with the new actions required by AWS when function URLs are used for public access.

# Related
- https://github.com/cds-snc/platform-core-services/issues/886