### PR TITLE
fix: remove the dependency outputs from the Terragrunt config

### DIFF
--- a/terragrunt/env/cloud_asset_inventory/terragrunt.hcl
+++ b/terragrunt/env/cloud_asset_inventory/terragrunt.hcl
@@ -13,11 +13,11 @@ dependency "base" {
 inputs = {
   tool_name                                       = "cloud-asset-inventory"
   cloud_asset_inventory_vpc_peering_connection_id = "pcx-0771c54d393000439"
-  security_tools_vpc_id                           = dependency.base.outputs.security_tools_vpc_id
-  vpc_private_subnet_cidrs                        = dependency.base.outputs.vpc_private_subnet_cidrs
-  vpc_public_subnet_cidrs                         = dependency.base.outputs.vpc_public_subnet_cidrs
-  vpc_private_subnet_ids                          = dependency.base.outputs.vpc_private_subnet_ids
-  vpc_public_subnet_ids                           = dependency.base.outputs.vpc_public_subnet_ids
+  security_tools_vpc_id                           = ""
+  vpc_private_subnet_cidrs                        = ""
+  vpc_public_subnet_cidrs                         = ""
+  vpc_private_subnet_ids                          = ""
+  vpc_public_subnet_ids                           = ""
 }
 
 include {


### PR DESCRIPTION
# Summary
The `base` dependency has been removed so these outputs no longer exist.

# Related
- https://github.com/cds-snc/security-tools/pull/570