### PR TITLE
fix: revert to single image Docker builds

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -62,6 +62,7 @@ jobs:
         working-directory: ./images/${{ matrix.image }}
         run: |
           docker build \
+          --provenance=false \
           --build-arg git_sha=$GITHUB_SHA \
           -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
           -t $REGISTRY/${{ matrix.image }}:latest .

--- a/.github/workflows/ci_build_containers.yml
+++ b/.github/workflows/ci_build_containers.yml
@@ -61,6 +61,7 @@ jobs:
         working-directory: ./${{ matrix.image }}
         run: |
           docker build \
+          --provenance=false \
           --build-arg git_sha=$GITHUB_SHA \
           -t $REGISTRY/${{ matrix.image }}:latest .
 


### PR DESCRIPTION
# Summary
Add `provenance=false` to the Docker builds so that we don't push multi-platform Docker image indexes to the ECR.  Lambda currently doesn't support these as a Docker image source.

The reason this fix is needed is because of the GitHub `ubuntu-latest` runner image change to include Docker v29.1.
