### PR TITLE
fix: remove unused environment variable and adjust boto3 import path …

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
@@ -22,10 +22,6 @@
       {
         "name": "AWS_REGION",
         "value": "${REGION}"
-      },
-      {
-        "name": "PYTHONUSERBASE",
-        "value": "/var/cartography/.local"
       }
     ],
     "mountPoints": [

--- a/terragrunt/aws/cloud_asset_inventory/container-definitions/generate_config.py
+++ b/terragrunt/aws/cloud_asset_inventory/container-definitions/generate_config.py
@@ -16,10 +16,21 @@ Required environment:
   AWS_REGION         - region for the generated profiles
   CONFIG_PATH        - output path (default /config/role_config)
 """
+import glob
 import os
 import sys
 
-import boto3
+# boto3 ships inside the cartography image's uv-managed tool environment, not on
+# the system python3's path. Add that environment's site-packages (resolved with
+# globs so we don't hardcode the python version or uv's internal layout) so this
+# script can import boto3 without needing a separate image.
+for _pattern in (
+    "/var/cartography/.local/share/uv/tools/*/lib/python*/site-packages",
+    "/var/cartography/.local/lib/python*/site-packages",
+):
+    sys.path[:0] = glob.glob(_pattern)
+
+import boto3  # noqa: E402  (imported after the sys.path bootstrap above)
 
 
 def require(name):


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the container definition and startup script for the cartography service in the cloud asset inventory. The main goal is to ensure the `generate_config.py` script can reliably import `boto3` from the uv-managed environment, without requiring changes to the base image or hardcoding Python paths. Additionally, it removes an unnecessary environment variable from the container definition.

Dependency import reliability:

* Updated `generate_config.py` to dynamically add uv-managed and user site-packages directories to `sys.path` using `glob`, ensuring `boto3` can be imported regardless of Python version or uv's internal layout. (`terragrunt/aws/cloud_asset_inventory/container-definitions/generate_config.py`)

Container definition cleanup:

* Removed the `PYTHONUSERBASE` environment variable from the cartography container definition, as it is no longer needed for dependency resolution. (`terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl`)