### PR TITLE
fix: change health check protocol from HTTPS to HTTP for sso_proxy

### DIFF
--- a/terragrunt/aws/sso_proxy/alb.tf
+++ b/terragrunt/aws/sso_proxy/alb.tf
@@ -34,7 +34,7 @@ resource "aws_lb_target_group" "sso_proxy" {
   vpc_id               = var.security_tools_vpc_id
 
   health_check {
-    protocol            = "HTTPS"
+    protocol            = "HTTP"
     path                = "/ping"
     port                = "traffic-port"
     timeout             = 10


### PR DESCRIPTION
# Summary | Résumé

This pull request makes a small but important change to the health check configuration for the `aws_lb_target_group.sso_proxy` resource. The health check protocol has been switched from `HTTPS` to `HTTP`.

* Changed the health check protocol from `HTTPS` to `HTTP` in the `aws_lb_target_group.sso_proxy` resource within `alb.tf`, which may affect how the load balancer checks the health of targets.