### PR TITLE
fix: add skip-module option for Azure in cartography configuration

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
@@ -88,7 +88,9 @@
       "--neo4j-password-env-var",
       "NEO4J_SECRETS_PASSWORD",
       "--aws-sync-all-profiles",
-      "--aws-best-effort-mode"
+      "--aws-best-effort-mode",
+      "--skip-module",
+      "azure"
     ],
     "secrets": [
       {


### PR DESCRIPTION
# Summary | Résumé

Skip azure modules to silence errors in Cartography task