### PR TITLE
fix: update cartography command to select AWS modules instead of skipping Azure

### DIFF
--- a/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
+++ b/terragrunt/aws/cloud_asset_inventory/container-definitions/cartography.json.tmpl
@@ -89,8 +89,8 @@
       "NEO4J_SECRETS_PASSWORD",
       "--aws-sync-all-profiles",
       "--aws-best-effort-mode",
-      "--skip-module",
-      "azure"
+      "--selected-modules",
+      "aws"
     ],
     "secrets": [
       {


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the container definition for the Cartography service to change how modules are selected during execution. Instead of skipping the Azure module, the configuration now explicitly selects the AWS module.

Container configuration update:

* Changed the Cartography container command to use `--selected-modules aws` instead of `--skip-module azure`, ensuring only the AWS module is run.