### PR TITLE
fix: duplicate CVE alerts, Trivy version bump

### DIFF
--- a/.github/actions/docker-scan/action.yml
+++ b/.github/actions/docker-scan/action.yml
@@ -25,9 +25,9 @@ runs:
   steps:
     - name: Install Trivy
       env:
-        TRIVY_VERSION: "0.69.3"
-        TRIVY_SHA256_AMD64: "1816b632dfe529869c740c0913e36bd1629cb7688bd5634f4a858c1d57c88b75"
-        TRIVY_SHA256_ARM64: "7e3924a974e912e57b4a99f65ece7931f8079584dae12eb7845024f97087bdfd"
+        TRIVY_VERSION: "0.71.2"
+        TRIVY_SHA256_AMD64: "0510e71e2fd39bf863856d499c8dc19feb4e7336546394c502a8f5cc7ab27460"
+        TRIVY_SHA256_ARM64: "fe1c7106e15a5365d485b098a8c338f91e3b7ba71cb0e4963b98a3a098763cfc"
       run: |
         bash "${{ github.action_path }}/../../scripts/install_trivy.sh" \
           "${{ env.TRIVY_VERSION }}" \

--- a/.github/actions/docker-scan/action.yml
+++ b/.github/actions/docker-scan/action.yml
@@ -52,7 +52,8 @@ runs:
         cat trivy-results.sarif | \
           jq '.runs[].results[].locations[].physicalLocation.artifactLocation += {"uri": "${{ inputs.dockerfile_path }}","uriBaseId": "ROOTPATH"}' | \
           jq '.runs[].results[].locations[].physicalLocation.region += {"startLine": 1,"startColumn": 1,"endLine": 1,"endColumn": 1}' | \
-          jq '.runs[].results[] |= (if .ruleId then . + {partialFingerprints: {"primaryLocationLineHash": .ruleId}} else . end)' > sarif.tmp
+          jq '.runs[].results[] |= (if .ruleId then . + {partialFingerprints: {"primaryLocationLineHash": .ruleId}} else . end)' | \
+          jq '.runs |= map(.results |= (group_by(.ruleId) | map(.[0])))' > sarif.tmp
         mv sarif.tmp trivy-results.sarif
       shell: bash
 


### PR DESCRIPTION
# Summary | Résumé

- Added a jq deduplication step to the SARIF pipeline that groups results by ruleId (the CVE ID) and keeps only one result per CVE before uploading
- Trivy version bump from 0.69.3 to 0.71.2


# Related

https://github.com/orgs/cds-snc/projects/51?pane=issue&itemId=200443365&issue=cds-snc%7Cplatform-core-services%7C1022